### PR TITLE
Allow logster to run in other environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,14 @@ constraints lambda { |req| req.session["admin"] } do
 end
 ```
 
+By default, logster will only run in development and production environments.
+
+To run logster in other environments, in `config/application.rb`
+
+```
+Logster.set_environments([:development, :staging, :production])
+```
+
 ### Note
 If you are seeing error
 'No such middleware to insert before: ActionDispatch::DebugExceptions' after installing logster,

--- a/lib/logster.rb
+++ b/lib/logster.rb
@@ -40,9 +40,14 @@ module Logster
     logster_env = Logster::Message.populate_from_env(env)
     logster_env[key] = value
   end
+
+  def self.set_environments(envs)
+    @config.environments = envs
+  end
 end
 
 Logster.config.current_context = lambda{ |env, &block| block.call }
+Logster.config.environments = [:development, :production]
 
 if defined?(::Rails) && ::Rails::VERSION::MAJOR.to_i >= 3
   require 'logster/rails/railtie'

--- a/lib/logster/configuration.rb
+++ b/lib/logster/configuration.rb
@@ -1,5 +1,5 @@
 module Logster
   class Configuration
-    attr_accessor :subdirectory, :current_context
+    attr_accessor :subdirectory, :current_context, :environments
   end
 end

--- a/lib/logster/rails/railtie.rb
+++ b/lib/logster/rails/railtie.rb
@@ -5,7 +5,7 @@ module Logster::Rails
   end
 
   def self.set_logger(config)
-    return unless Rails.env.development? || Rails.env.production?
+    return unless Logster.config.environments.include?(Rails.env.to_sym)
 
     require 'logster/middleware/debug_exceptions'
     require 'logster/middleware/reporter'
@@ -22,7 +22,7 @@ module Logster::Rails
 
 
   def self.initialize!(app)
-    return unless Rails.env.development? || Rails.env.production?
+    return unless Logster.config.environments.include?(Rails.env.to_sym)
 
     if Logster::Logger === Rails.logger
       app.middleware.insert_before ActionDispatch::ShowExceptions, Logster::Middleware::Reporter


### PR DESCRIPTION
Use new configuration 'environments' to manage the running
environments of logster and allow user to override it.