### PR TITLE
Better fonts for OS X and Ubuntu

### DIFF
--- a/assets/stylesheets/app.css
+++ b/assets/stylesheets/app.css
@@ -36,7 +36,7 @@ td.time {
   vertical-align: top;
 }
 .message {
-  font-family: Consolas, mono;
+  font-family: Consolas, Monaco, Ubuntu Mono, monospace;
   font-size: 13px;
   overflow: hidden;
   white-space: nowrap;


### PR DESCRIPTION
Currently logster use scary default serif fonts there since Consolas is Windows-only.