### PR TITLE
Inherit logger from ActiveSupport::Logger if it's available

### DIFF
--- a/lib/logster/logger.rb
+++ b/lib/logster/logger.rb
@@ -1,7 +1,9 @@
 require 'logger'
 
 module Logster
-  class Logger < ::Logger
+
+  class Logger < Class.new(const_defined?('ActiveSupport::Logger') ? ActiveSupport::Logger : ::Logger)
+
     LOGSTER_ENV = "logster_env".freeze
 
     attr_accessor :store, :skip_store


### PR DESCRIPTION
I was getting the same error as described in issue #48, so I made this fix. This is what the problem is:

Since `Logster::Logger` taps into Rails logger, it should have the same interface as Rails logger. But `Logster::Logger` inherits from `::Logger` class, whereas Rails logger is an instance of `ActiveSupport::Logger` class ( which adds a few methods on top of `::Logger` class). So whenever any of those added methods is called, Logster fails with `NoMethodError`.

So my solution is basically to use Rails-specific logger when Logster runs in Rails environment, and default to the generic one otherwise. What do you think?
