### PR TITLE
link to Ember components/templates instead of inline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+.byebug_history

--- a/logster.gemspec
+++ b/logster.gemspec
@@ -30,4 +30,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "guard"
   spec.add_development_dependency "guard-minitest"
   spec.add_development_dependency "timecop"
+  spec.add_development_dependency "byebug"
 end

--- a/test/logster/middleware/test_viewer.rb
+++ b/test/logster/middleware/test_viewer.rb
@@ -67,4 +67,41 @@ class TestViewer < Minitest::Test
     assert_equal(/hello/i, viewer.send(:parse_regex, '/hello/i'))
   end
 
+  def test_linking_to_a_valid_ember_component
+    status, headers, body = viewer.call(
+      'PATH_INFO' => '/logsie/javascript/components/message-row.js',
+      'REQUEST_METHOD' => 'GET'
+    )
+
+    assert_equal(200, status)
+    assert_equal('application/javascript', headers['Content-Type'])
+    assert_match(/Ember.TEMPLATES\["components\/message-row"\]/, body.first)
+  end
+
+  def test_linking_to_a_valid_ember_template
+    status, headers, body = viewer.call(
+      'PATH_INFO' => '/logsie/javascript/templates/application.js',
+      'REQUEST_METHOD' => 'GET'
+    )
+
+    assert_equal(200, status)
+    assert_equal('application/javascript', headers['Content-Type'])
+    assert_match(/Ember.TEMPLATES\["application"\]/, body.first)
+  end
+
+  def test_linking_to_an_invalid_ember_component_or_template
+    %w(
+      /logsie/javascript/templates/application.hbs
+      /logsie/javascript/templates/does_not_exist.js
+      /logsie/javascript/components/does_not_exist.js
+      /logsie/javascript/templates/../../app.js
+    ).each do |path|
+      status, _ = viewer.call(
+        'PATH_INFO' => path,
+        'REQUEST_METHOD' => 'GET'
+      )
+
+      assert_equal(404, status, "#{path} should have 404'ed")
+    end
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,6 +6,7 @@ require 'redis'
 require 'logster'
 require 'logster/base_store'
 require 'timecop'
+require 'byebug'
 
 class Logster::TestStore < Logster::BaseStore
   attr_accessor :reported


### PR DESCRIPTION
This is part one of removing Logster's inline JavaScripts: adding a `/javascript/template/:name.js` route that responds with a "compiled" version of the Ember handlebar template/component.

**In the future**, is it worth investing time to integrate a proper asset pipeline/manager into Logster?