### PR TITLE
extract all inline script tags

### DIFF
--- a/assets/javascript/app.js
+++ b/assets/javascript/app.js
@@ -16,6 +16,11 @@ moment.lang('en', {
       }
 });
 
+var preloaded = document.getElementById('preloaded-data').dataset;
+var Logger = {
+   rootPath: preloaded.rootPath,
+   preload: JSON.parse(preloaded.preloaded)
+};
 
 App = Ember.Application.create({
 });
@@ -48,6 +53,11 @@ App.preloadOrAjax = function(url, settings) {
 App.Router.map(function() {
   this.route("index", { path: "/" });
   this.route("show", { path: "/show/:id" });
+});
+
+App.Router.reopen({
+  rootURL: Logger.rootPath,
+  location: 'history'
 });
 
 var entityMap = {

--- a/lib/logster/middleware/viewer.rb
+++ b/lib/logster/middleware/viewer.rb
@@ -213,6 +213,10 @@ module Logster
         "Ember.TEMPLATES[#{name.inspect}] = Ember.Handlebars.compile(#{val.inspect});"
       end
 
+      def to_json_and_escape(payload)
+        Rack::Utils.escape_html(JSON.fast_generate(payload))
+      end
+
       def body(preload)
 <<HTML
 <!doctype html>
@@ -239,21 +243,10 @@ module Logster
   #{component("panel-resizer")}
   #{template("index")}
   #{template("show")}
-  <script>
-    window.Logger = {
-       rootPath: "#{@logs_path}",
-       preload: #{JSON.fast_generate(preload).gsub("</", "<\\/")}
-    };
-  </script>
+  <meta id="preloaded-data" data-root-path="#{@logs_path}" data-preloaded="#{to_json_and_escape(preload)}">
 </head>
 <body>
   #{script("app.js")}
-  <script>
-    App.Router.reopen({
-      rootURL: Logger.rootPath,
-      location: 'history'
-    });
-  </script>
 </body>
 </html>
 HTML


### PR DESCRIPTION
I tested the change locally with Discourse, and also tried removing Logster from [the CSP whitelist](https://github.com/discourse/discourse/blob/306d77b54f5d3089c08d9e068737a7cb91997ecb/lib/content_security_policy.rb#L9) and it works 🎊 We are ready for a version bump! 