### PR TITLE
Respect when Rails is using a tagged logger

### DIFF
--- a/lib/logster/rails/railtie.rb
+++ b/lib/logster/rails/railtie.rb
@@ -17,7 +17,9 @@ module Logster::Rails
     original_logger = ::Rails.logger
     logger.chain(original_logger)
     logger.level = ::Rails.logger.level
-    logger = ActiveSupport::TaggedLogging.new(logger) if original_logger.respond_to?(:clear_tags!, true)
+    if defined?(ActiveSupport::TaggedLogging) && ActiveSupport::TaggedLogging === original_logger
+      logger = ActiveSupport::TaggedLogging.new(original_logger)
+    end
     Logster.logger = ::Rails.logger = config.logger = logger
   end
 

--- a/lib/logster/rails/railtie.rb
+++ b/lib/logster/rails/railtie.rb
@@ -14,9 +14,10 @@ module Logster::Rails
     store.level = Logger::Severity::WARN if Rails.env.production?
 
     logger = Logster::Logger.new(store)
-    logger.chain(::Rails.logger)
+    original_logger = ::Rails.logger
+    logger.chain(original_logger)
     logger.level = ::Rails.logger.level
-
+    logger = ActiveSupport::TaggedLogging.new(logger) if original_logger.respond_to?(:clear_tags!, true)
     Logster.logger = ::Rails.logger = config.logger = logger
   end
 


### PR DESCRIPTION
Wrap Logster.logger in ActiveSupport::TaggedLogging when the Rails.logger has the tagged logging interface.

Prevents Logster from crashing the Rails app when a setup uses a tagged logger in the stack.

For example, my setup surprisingly failed in production

```
2018-10-24T15:42:08.235269+00:00 app[web.1]: 2018-10-24 15:42:08 +0000: Rack app error handling request { GET /v1/users }
2018-10-24T15:42:08.235271+00:00 app[web.1]: #<NoMethodError: undefined method `clear_tags!' for #<Logster::Logger:0x0000000004888c78>>
2018-10-24T15:42:08.235273+00:00 app[web.1]: /app/vendor/bundle/ruby/2.4.0/gems/faraday-detailed_logger-2.1.2/lib/faraday/detailed_logger/tagged_logging.rb:74:in `flush'
2018-10-24T15:42:08.235274+00:00 app[web.1]: /app/vendor/bundle/ruby/2.4.0/gems/activesupport-5.0.7/lib/active_support/log_subscriber.rb:70:in `flush_all!'
2018-10-24T15:42:08.235275+00:00 app[web.1]: /app/vendor/bundle/ruby/2.4.0/gems/lograge-0.10.0/lib/lograge/rails_ext/rack/logger.rb:17:in `call_app'
2018-10-24T15:42:08.235277+00:00 app[web.1]: /app/vendor/bundle/ruby/2.4.0/gems/railties-5.0.7/lib/rails/rack/logger.rb:24:in `block in call'
2018-10-24T15:42:08.235279+00:00 app[web.1]: /app/vendor/bundle/ruby/2.4.0/gems/faraday-detailed_logger-2.1.2/lib/faraday/detailed_logger/tagged_logging.rb:70:in `block in tagged'
2018-10-24T15:42:08.235280+00:00 app[web.1]: /app/vendor/bundle/ruby/2.4.0/gems/faraday-detailed_logger-2.1.2/lib/faraday/detailed_logger/tagged_logging.rb:25:in `tagged'
2018-10-24T15:42:08.235281+00:00 app[web.1]: /app/vendor/bundle/ruby/2.4.0/gems/faraday-detailed_logger-2.1.2/lib/faraday/detailed_logger/tagged_logging.rb:70:in `tagged'
2018-10-24T15:42:08.235282+00:00 app[web.1]: /app/vendor/bundle/ruby/2.4.0/gems/railties-5.0.7/lib/rails/rack/logger.rb:24:in `call'
2018-10-24T15:42:08.235284+00:00 app[web.1]: /app/vendor/bundle/ruby/2.4.0/gems/request_store-1.4.1/lib/request_store/middleware.rb:19:in `call'
2018-10-24T15:42:08.235285+00:00 app[web.1]: /app/vendor/bundle/ruby/2.4.0/gems/actionpack-5.0.7/lib/action_dispatch/middleware/request_id.rb:24:in `call'
2018-10-24T15:42:08.235286+00:00 app[web.1]: /app/vendor/bundle/ruby/2.4.0/gems/rack-2.0.5/lib/rack/method_override.rb:22:in `call'
2018-10-24T15:42:08.235288+00:00 app[web.1]: /app/vendor/bundle/ruby/2.4.0/gems/rack-2.0.5/lib/rack/runtime.rb:22:in `call'
2018-10-24T15:42:08.235289+00:00 app[web.1]: /app/vendor/bundle/ruby/2.4.0/gems/activesupport-5.0.7/lib/active_support/cache/strategy/local_cache_middleware.rb:28:in `call'
2018-10-24T15:42:08.235291+00:00 app[web.1]: /app/vendor/bundle/ruby/2.4.0/gems/actionpack-5.0.7/lib/action_dispatch/middleware/executor.rb:12:in `call'
2018-10-24T15:42:08.235292+00:00 app[web.1]: /app/vendor/bundle/ruby/2.4.0/gems/actionpack-5.0.7/lib/action_dispatch/middleware/static.rb:136:in `call'
2018-10-24T15:42:08.235294+00:00 app[web.1]: /app/vendor/bundle/ruby/2.4.0/gems/rack-2.0.5/lib/rack/sendfile.rb:111:in `call'
2018-10-24T15:42:08.235295+00:00 app[web.1]: /app/vendor/bundle/ruby/2.4.0/gems/rack-cors-1.0.2/lib/rack/cors.rb:97:in `call'
2018-10-24T15:42:08.235296+00:00 app[web.1]: /app/vendor/bundle/ruby/2.4.0/gems/scout_apm-2.4.19/lib/scout_apm/instruments/middleware_summary.rb:58:in `call'
2018-10-24T15:42:08.235297+00:00 app[web.1]: /app/vendor/bundle/ruby/2.4.0/gems/railties-5.0.7/lib/rails/engine.rb:522
```

where I have lograge, faraday-detailed_logger, logster, and the below initializer in `config/application.rb`

```ruby
    if ENV["RAILS_LOG_TO_STDOUT"].present?
      initializer(:custom_stdout_logging, before: :initialize_logger) do
        logger           = ActiveSupport::Logger.new(STDOUT)
        logger.formatter = config.log_formatter
        logger.level = config.log_level
        logger = ActiveSupport::TaggedLogging.new(logger)
        ::Rails.logger = config.logger = logger
        # Disable double loggging
        if defined?(Rails::Console)
          ActiveSupport::Logger.class_eval do
            def self.broadcast(logger)
              puts "logger broadcast disabled: #{logger.inspect}"
              Module.new do end
            end
          end
        end
```

Arguably, this shouldn't crash the app in the first place, but nonetheless, I resolved the issue with an initializer

```
if defined?(Logster) && Rails.logger.is_a?(Logster::Logger) && !Rails.logger.respond_to?(:clear_tags!, true)
  STDERR.puts "Extending Logster to be compatible with tagged logging" if Rails.logger.level == Logger::DEBUG
  Rails.logger = ActiveSupport::TaggedLogging.new(Rails.logger)
end
```