### PR TITLE
FIX: Content-Length header value must be string

### DIFF
--- a/lib/logster/middleware/viewer.rb
+++ b/lib/logster/middleware/viewer.rb
@@ -35,7 +35,7 @@ module Logster
             if status == 200
               body = [compile_hbs(body.to_path, type, name)]
               headers['Content-Type'] = 'application/javascript'
-              headers['Content-Length'] = body.first.bytesize
+              headers['Content-Length'] = body.first.bytesize.to_s
             end
 
             [status, headers, body]


### PR DESCRIPTION
@OsamaSayegh caught this when running `rackup` in `/website`:

```text
Rack::Lint::LintError: a header value must be a String, but the value of 'Content-Length' is a Integer
```

`rackup` by default wraps the application with the `Rack::Lint` middleware [in development environment](https://github.com/rack/rack/blob/7420be230f73ed350fb0aea612d0ea98cb451778/lib/rack/server.rb#L262). It makes sure new middleware complies with the [rack specifications](https://www.rubydoc.info/github/rack/rack/file/SPEC), and does not affect any production sites.

This also restructures `TestViewer` to catch future `Rack::Lint` errors.