### PR TITLE
Logger.add interface only requires level, message

### DIFF
--- a/lib/logster/logger.rb
+++ b/lib/logster/logger.rb
@@ -57,7 +57,7 @@ module Logster
       (ol && ol[Thread.current.object_id]) || @level
     end
 
-    def add_with_opts(severity, message, progname, opts=nil, &block)
+    def add_with_opts(severity, message, progname=progname(), opts=nil, &block)
       if severity < level
         return true
       end


### PR DESCRIPTION
I propose falling back to the instance method `progname()` when a logger message is added without an explicit progname, such as `logger.add 1, "Test message"`

Without this change, I get 

> ArgumentError: wrong number of arguments (given 0, expected 1..3)
> 	from /app/vendor/bundle/ruby/2.4.0/gems/logster-1.2.11/lib/logster/logger.rb:59:in `add_with_opts'

when calling `Rails.logger.add 1, "Test Message"`