### PR TITLE
Assign nil to progname as default value

### DIFF
--- a/lib/logster/logger.rb
+++ b/lib/logster/logger.rb
@@ -49,7 +49,7 @@ module Logster
     end
 
     def add(*args, &block)
-      add_with_opts(*args,&block)
+      add_with_opts(*args, &block)
     end
 
     def level

--- a/test/logster/test_logger.rb
+++ b/test/logster/test_logger.rb
@@ -61,6 +61,12 @@ class TestLogger < Minitest::Test
     end
   end
 
+  def test_progname_parameter
+    @logger.add(0, "test")
+    progname = @store.calls[0][1]
+    assert_nil progname
+  end
+
   class PlayLogger
     attr_accessor :skip_store
     def initialize(tester)


### PR DESCRIPTION
Users are able to do `logger.add(0, "message")` in Ruby logger, however in logster, it raises error. See:

``` ruby
class TestStore
  attr_accessor :calls

  def report(*args)
    (@calls ||= []) << args
  end
end

store = TestStore.new
logger = Logster::Logger.new(store)

# Before
logger.add(Logger::INFO, "message")
# 2: from /Users/who/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/logster-1.2.11/lib/logster/logger.rb:51:in `add'
# 1: from /Users/who/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/logster-1.2.11/lib/logster/logger.rb:59:in `add_with_opts'

# After
irb(main):013:0> logger.add 0, "message"
=> [[0, nil, "message", {:env=>nil}]]
```