### PR TITLE
FEATURE: Keep track of message timestamp when it's merged

### DIFF
--- a/assets/javascript/client-app.js
+++ b/assets/javascript/client-app.js
@@ -104,23 +104,24 @@ function a(){var e=document.getElementById("preloaded-data").dataset
 t=Em.$.extend(JSON.parse(e.preloaded),{rootPath:e.rootPath}),n=!0}var s={get:function(e){return n||a(),Em.get(t,e)}}
 e.default=s}),define("client-app/lib/utilities",["exports","@babel/runtime/helpers/esm/typeof","client-app/lib/preload"],function(e,t,n){Object.defineProperty(e,"__esModule",{value:!0}),e.escapeHtml=o,e.ajax=l,e.preloadOrAjax=function(e,t){var a=n.default.get(e.replace(".json",""))
 return a?Em.RSVP.resolve(a):l(e,t)},e.updateHiddenProperty=function(e){a=e},e.isHidden=u,e.increaseTitleCount=function(e){if(!u())return
-s=s||document.title,i=i||0,i+=e,document.title="".concat(s," (").concat(i,")")},e.resetTitleCount=function(){i=0,document.title=s||document.title},e.formatTime=function(e){var t,n=moment(e),a=moment()
-t=n.diff(a.startOf("day"))>0?n.format("h:mm a"):n.diff(a.startOf("week"))>0?n.format("dd h:mm a"):n.diff(a.startOf("year"))>0?n.format("D MMM h:mm a"):n.format("D MMM YY")
-return t},e.buildArrayString=c,e.buildHashString=function e(a,s){var i=arguments.length>2&&void 0!==arguments[2]?arguments[2]:[]
+s=s||document.title,i=i||0,i+=e,document.title="".concat(s," (").concat(i,")")},e.resetTitleCount=function(){i=0,document.title=s||document.title},e.formatTime=c,e.buildArrayString=d,e.buildHashString=function e(a,s){var i=arguments.length>2&&void 0!==arguments[2]?arguments[2]:[]
 if(!a)return""
 var r=[]
 var l=[]
 var u=n.default.get("env_expandable_keys")||[]
 _.each(a,function(e,n){if(null===e)r.push("null")
 else if("[object Array]"===Object.prototype.toString.call(e)){var a=""
-a=-1!==u.indexOf(n)&&!s&&-1===i.indexOf(n)&&e.length>3?"".concat(o(e[0]),', <a class="expand-list" data-key=').concat(n,">").concat(e.length-1," more</a>"):c(e),r.push("<tr><td>"+o(n)+"</td><td>"+a+"</td></tr>")}else"object"===(0,t.default)(e)?l.push(n):r.push("<tr><td>"+o(n)+"</td><td>"+o(e)+"</td></tr>")})
+a=-1!==u.indexOf(n)&&!s&&-1===i.indexOf(n)&&e.length>3?"".concat(o(e[0]),', <a class="expand-list" data-key=').concat(n,">").concat(e.length-1," more</a>"):d(e),r.push("<tr><td>"+o(n)+"</td><td>"+a+"</td></tr>")}else if("object"===(0,t.default)(e))l.push(n)
+else if("time"===n&&"number"==typeof e){var p=moment(e).format(),f=c(e)
+r.push('<tr title="'.concat(p,'"><td>').concat(n,"</td><td>").concat(f,"</td></tr>"))}else r.push("<tr><td>".concat(o(n),"</td><td>").concat(o(e),"</td></tr>"))})
 _.size(l)>0&&_.each(l,function(t){var n=a[t]
 r.push("<tr><td></td><td><table>"),r.push("<td>"+o(t)+"</td><td>"+e(n,!0)+"</td>"),r.push("</table></td></tr>")})
-var d=s?"":"env-table"
-return"<table class='"+d+"'>"+r.join("\n")+"</table>"}
+var p=s?"":"env-table"
+return"<table class='"+p+"'>"+r.join("\n")+"</table>"}
 var a,s,i,r={"&":"&amp;","<":"&lt;",">":"&gt;",'"':"&quot;","'":"&#39;","/":"&#x2F;"}
-function o(e){return String(e).replace(/[&<>"'\/]/g,function(e){return r[e]})}function l(e,t){return(t=t||{}).headers=t.headers||{},t.headers["X-SILENCE-LOGGER"]=!0,Em.$.ajax(n.default.get("rootPath")+e,t)}function u(){return void 0!==a?document[a]:!document.hasFocus}function c(e){var t=[]
-return e.forEach(function(e){null===e?t.push("null"):"[object Array]"===Object.prototype.toString.call(e)?t.push(c(e)):t.push(o(e.toString()))}),"["+t.join(", ")+"]"}}),define("client-app/models/message-collection",["exports","client-app/lib/utilities","client-app/models/message"],function(e,t,n){Object.defineProperty(e,"__esModule",{value:!0}),e.default=void 0
+function o(e){return String(e).replace(/[&<>"'\/]/g,function(e){return r[e]})}function l(e,t){return(t=t||{}).headers=t.headers||{},t.headers["X-SILENCE-LOGGER"]=!0,Em.$.ajax(n.default.get("rootPath")+e,t)}function u(){return void 0!==a?document[a]:!document.hasFocus}function c(e){var t=moment(e),n=moment()
+return t.diff(n.startOf("day"))>0?t.format("h:mm a"):t.diff(n.startOf("week"))>0?t.format("dd h:mm a"):t.diff(n.startOf("year"))>0?t.format("D MMM h:mm a"):t.format("D MMM YY")}function d(e){var t=[]
+return e.forEach(function(e){null===e?t.push("null"):"[object Array]"===Object.prototype.toString.call(e)?t.push(d(e)):t.push(o(e.toString()))}),"["+t.join(", ")+"]"}}),define("client-app/models/message-collection",["exports","client-app/lib/utilities","client-app/models/message"],function(e,t,n){Object.defineProperty(e,"__esModule",{value:!0}),e.default=void 0
 var a=Em.Object.extend({messages:Em.A(),currentMessage:null,total:0,solve:function(e){var t=this
 e.solve().then(function(){t.reload()})},destroy:function(e){var t=this.get("messages"),n=t.indexOf(e)
 e.destroy(),e.set("selected",!1),this.set("total",this.get("total")-1),this.get("messages").removeObject(e),n>0?((e=t[n-1]).set("selected",!0),this.set("currentMessage",e)):this.get("total")>0?((e=t[0]).set("selected",!0),this.set("currentMessage",e)):this.reload()},load:function(e){var n=this
@@ -194,4 +195,4 @@ var t=Ember.HTMLBars.template({id:"K64jJk76",block:'{"symbols":[],"statements":[
 e.default=t}),define("client-app/templates/show",["exports"],function(e){Object.defineProperty(e,"__esModule",{value:!0}),e.default=void 0
 var t=Ember.HTMLBars.template({id:"V916vpg9",block:'{"symbols":[],"statements":[[4,"link-to",["index"],null,{"statements":[[0,"Recent"]],"parameters":[]},null],[0,"\\n"],[7,"div"],[11,"id","bottom-panel"],[11,"class","full"],[9],[0,"\\n  "],[1,[27,"message-info",null,[["currentMessage","showTitle","actionsInMenu"],[[23,["model"]],"true",false]]],false],[0,"\\n"],[10],[0,"\\n"]],"hasEval":false}',meta:{moduleName:"client-app/templates/show.hbs"}})
 e.default=t}),define("client-app/config/environment",[],function(){try{var e="client-app/config/environment",t=document.querySelector('meta[name="'+e+'"]').getAttribute("content"),n={default:JSON.parse(decodeURIComponent(t))}
-return Object.defineProperty(n,"__esModule",{value:!0}),n}catch(a){throw new Error('Could not read config from meta tag with name "'+e+'".')}}),runningTests||require("client-app/app").default.create({name:"client-app",version:"0.0.0+acb9fc29"})
+return Object.defineProperty(n,"__esModule",{value:!0}),n}catch(a){throw new Error('Could not read config from meta tag with name "'+e+'".')}}),runningTests||require("client-app/app").default.create({name:"client-app",version:"v2.3.2+3ee689f3"})

--- a/client-app/app/lib/utilities.js
+++ b/client-app/app/lib/utilities.js
@@ -125,9 +125,15 @@ export function buildHashString(hash, recurse, expanded = []) {
     } else if (typeof v === "object") {
       hashes.push(k);
     } else {
-      buffer.push(
-        "<tr><td>" + escapeHtml(k) + "</td><td>" + escapeHtml(v) + "</td></tr>"
-      );
+      if (k === "time" && typeof v === "number") {
+        const title = moment(v).format();
+        const time = formatTime(v);
+        buffer.push(`<tr title="${title}"><td>${k}</td><td>${time}</td></tr>`);
+      } else {
+        buffer.push(
+          `<tr><td>${escapeHtml(k)}</td><td>${escapeHtml(v)}</td></tr>`
+        );
+      }
     }
   });
 

--- a/client-app/tests/integration/components/env-tab-test.js
+++ b/client-app/tests/integration/components/env-tab-test.js
@@ -5,8 +5,11 @@ import hbs from "htmlbars-inline-precompile";
 import Message from "client-app/models/message";
 import { init } from "client-app/lib/preload";
 
+const time1 = new Date("2010-01-01T01:00:00").getTime();
+const time2 = new Date("2015-01-01T01:00:00").getTime();
+
 const message = Message.create({
-  env: [{ a: "aa", b: "bb" }, { c: "cc", d: "dd" }]
+  env: [{ a: "aa", b: "bb", time: time1 }, { c: "cc", d: "dd", time: time2 }]
 });
 
 const message2 = Message.create({
@@ -41,9 +44,14 @@ module("Integration | Component | env-tab", function(hooks) {
       "shows the current over the total number of env objects"
     );
     let trs = findAll("tr");
-    assert.equal(trs.length, 2);
+    assert.equal(trs.length, 3);
     assert.equal(reduceToContent(trs[0]), "a: aa", "has the right content");
     assert.equal(reduceToContent(trs[1]), "b: bb", "has the right content");
+    assert.equal(
+      reduceToContent(trs[2]),
+      "time: 1 Jan 10",
+      "has the right content"
+    );
 
     const buttons = findAll("button.nav-btn");
     // at first page, you can't go back
@@ -76,9 +84,14 @@ module("Integration | Component | env-tab", function(hooks) {
     );
 
     const trs = findAll("tr");
-    assert.equal(trs.length, 2);
+    assert.equal(trs.length, 3);
     assert.equal(reduceToContent(trs[0]), "c: cc", "has the right content");
     assert.equal(reduceToContent(trs[1]), "d: dd", "has the right content");
+    assert.equal(
+      reduceToContent(trs[2]),
+      "time: 1 Jan 15",
+      "has the right content"
+    );
 
     // at last page, you can't go forward but you can go back
     assert.notOk(buttons[0].disabled, "back buttons are not disabled");

--- a/lib/logster/message.rb
+++ b/lib/logster/message.rb
@@ -141,6 +141,13 @@ module Logster
       return false if self.count > Logster::MAX_GROUPING_LENGTH
 
       other_env = JSON.load JSON.fast_generate other.env
+      if Hash === other_env && !other_env.key?("time")
+        other_env["time"] = other.timestamp
+      end
+      if Hash === self.env && !self.env.key?("time")
+        self.env["time"] = self.first_timestamp
+      end
+
       if Array === self.env
         Array === other_env ? self.env.concat(other_env) : self.env << other_env
       else

--- a/test/logster/test_message.rb
+++ b/test/logster/test_message.rb
@@ -23,6 +23,20 @@ class TestMessage < MiniTest::Test
     assert({ "a" => "2", "c" => "3" } <= msg1.env[1])
   end
 
+  def test_merge_adds_timestamp_to_env
+    time1 = Time.new(2010, 1, 1, 1, 1).to_i
+    msg1 = Logster::Message.new(0, '', 'test', time1)
+    msg1.env = { a: "aa", b: "bb" }
+
+    time2 = Time.new(2011, 1, 1, 1, 1).to_i
+    msg2 = Logster::Message.new(0, '', 'test', time2)
+    msg2.env = { e: "ee", f: "ff" }
+
+    msg1.merge_similar_message(msg2)
+    assert_equal(time1, msg1.env[0]["time"])
+    assert_equal(time2, msg1.env[1]["time"])
+  end
+
   def test_merge_messages_both_with_array_envs
     msg1 = Logster::Message.new(0, '', 'test', 10)
     msg1.env = [{ a: "aa", b: "bb" }, { c: "cc", d: "dd" }]
@@ -49,8 +63,8 @@ class TestMessage < MiniTest::Test
     msg1.merge_similar_message(msg2)
 
     assert_equal(msg1.env.size, 3)
-    assert_equal(msg1.env.map(&:keys).flatten(1).map(&:to_s), %w{a b c d e f})
-    assert_equal(msg1.env.map(&:values).flatten(1).map(&:to_s), %w{aa bb cc dd ee ff})
+    assert_equal(msg1.env.map(&:keys).flatten(1).map(&:to_s), %w{a b c d e f time})
+    assert_equal(msg1.env.map(&:values).flatten(1).map(&:to_s), %w{aa bb cc dd ee ff 20})
   end
 
   def test_adds_application_version


### PR DESCRIPTION
Currently when similar messages are grouped, we lose the timestamps of all the messages that are merged except for the most recent message's timestamp. What this PR does is it stores the timestamp of the message to be merged in its env hash (which is then added to the array of envs of the "grouping" message) so you can see the individual timestamp of each merged message.

Screenshot:

![image](https://user-images.githubusercontent.com/17474474/66206239-34758a00-e6b8-11e9-93bb-3ac03aa7f4b2.png)
