### PR TITLE
PERF: Cap message size to 60,000 bytes by default

### DIFF
--- a/lib/logster/base_store.rb
+++ b/lib/logster/base_store.rb
@@ -183,13 +183,12 @@ module Logster
       end
 
       if similar
-        has_env = !similar.env.nil? && !similar.env.empty?
-        if similar.count < Logster::MAX_GROUPING_LENGTH && !has_env
+        if similar.count < Logster::MAX_GROUPING_LENGTH
           similar.env = get_env(similar.key) || {}
         end
         save_env = similar.merge_similar_message(message)
 
-        replace_and_bump(similar, save_env: save_env || has_env)
+        replace_and_bump(similar, save_env: save_env)
         similar
       else
         save message

--- a/lib/logster/configuration.rb
+++ b/lib/logster/configuration.rb
@@ -11,7 +11,8 @@ module Logster
       :enable_js_error_reporting,
       :environments,
       :rate_limit_error_reporting,
-      :web_title
+      :web_title,
+      :maximum_message_size_bytes
     )
 
     attr_writer :subdirectory
@@ -25,6 +26,7 @@ module Logster
       @enable_custom_patterns_via_ui = false
       @rate_limit_error_reporting = true
       @enable_js_error_reporting = true
+      @maximum_message_size_bytes = 60_000
 
       @allow_grouping = false
 


### PR DESCRIPTION
This PR introduces a (configurable) limit to the number of bytes that a message can get to in size. You can configure the limit via the `maximum_message_size_bytes` option. This limit isn't very strict, meaning a message can still grow a few bytes beyond the limit but not by too much.

However, there is still a couple of scenarios that could make the message considerably larger than the limit:

1. When the message backtrace has way too many frames. We could fix this by trimming the backtrace at line (or character) X? Maybe keep the first 60 lines?

2. When env is a single `Hash` and it's gigantic. I've never seen this so I think it's rare, I'm not sure what's the best way to handle this or if we should handle this at all? Maybe remove keys arbitrarily until size is < the limit? Drop env entirely if this happens?

I think this PR handles the **majority** of cases, since 60K bytes is fairly generous and is enough to easily accommodate a message with 50 average envs.