### PR TITLE
FIX: wrong number of arguments when adding message using a block

### DIFF
--- a/lib/logster/logger.rb
+++ b/lib/logster/logger.rb
@@ -57,7 +57,7 @@ module Logster
       (ol && ol[Thread.current.object_id]) || @level
     end
 
-    def add_with_opts(severity, message, progname = progname(), opts = nil, &block)
+    def add_with_opts(severity, message = nil, progname = progname(), opts = nil, &block)
       if severity < level
         return true
       end

--- a/test/logster/test_logger.rb
+++ b/test/logster/test_logger.rb
@@ -61,6 +61,13 @@ class TestLogger < Minitest::Test
     end
   end
 
+  def test_add_with_one_argument
+    @logger.add(2) { "test" }
+    @logger.add(2)
+    assert_equal 2, @store.calls.length
+    assert_equal "test", @store.calls.first[2]
+  end
+
   class NewLogger < Logster::Logger; end
 
   def test_inherited_logger_backtrace_with_chain


### PR DESCRIPTION
Logger add should allow one argument.

logger.add(Logger::ERROR) { "the message" }

https://ruby-doc.org/stdlib-2.6/libdoc/logger/rdoc/Logger.html#method-i-add