### PR TITLE
PERF: Make truncating backtraces more memory-efficient

### DIFF
--- a/lib/logster.rb
+++ b/lib/logster.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'logster/version'
 require 'logster/logger'
 require 'logster/message'
 require 'logster/configuration'


### PR DESCRIPTION
Recently we merged this PR https://github.com/discourse/logster/pull/103 that introduced a new config that limited the message's total size to X bytes and X is 10,000 by default. If a message is above the limit, then logster will eat away from the backtrace until the message size goes below the limit. This caused a big performance regression because the implementation is not so great performance-wise; it allocates tons of string and array objects while reducing the message size.

This PR should bring the performance back to about what it was before merging https://github.com/discourse/logster/pull/103.

Some benchmark numbers:

```
Before this PR:
Time taken: 3649.959228515625 (ms)
==================================================
Total allocated: 1.03 GB (3780401 objects)
```

```
After this PR:
Time taken: 1736.82861328125 (ms)
==================================================
Total allocated: 274.55 MB (702720 objects)
```

My benchmark script reports the same message 2000 times to Logster and measures how long it takes and how much memory is allocated.