### PR TITLE
FIX: Stop env mutation to allow all chained loggers to have the same env

### DIFF
--- a/lib/logster/base_store.rb
+++ b/lib/logster/base_store.rb
@@ -156,7 +156,7 @@ module Logster
       msg = truncate_message(msg)
       message = Logster::Message.new(severity, progname, msg, opts[:timestamp], count: opts[:count])
 
-      env = opts[:env] || {}
+      env = opts[:env].dup || {}
       backtrace = opts[:backtrace]
       if Hash === env && env[:backtrace]
         # Special - passing backtrace through env

--- a/lib/logster/base_store.rb
+++ b/lib/logster/base_store.rb
@@ -156,7 +156,7 @@ module Logster
       msg = truncate_message(msg)
       message = Logster::Message.new(severity, progname, msg, opts[:timestamp], count: opts[:count])
 
-      env = opts[:env].dup || {}
+      env = opts[:env]&.dup || {}
       backtrace = opts[:backtrace]
       if Hash === env && env[:backtrace]
         # Special - passing backtrace through env


### PR DESCRIPTION
Logster allows the backtrace of a message to be provided via its `env`. This can be done by setting the `env` hash in the current thread's storage like so `Thread.current[Logster::Logger::LOGSTER_ENV] = env_with_backtrace`. Logster also has the ability to chain multiple loggers that do different things. The problem here is that if one of the chained loggers mutate something, that change may cause the remaining loggers to behave differently.

An example of this problem is `base_store.rb` at line 163 it does this: `backtrace = env.delete(:backtrace)`. This affects us at Discourse where we ship all the logs from sites we host to a central place by adding a logger to logster's chain. The problem we're seeing is that the same log message has a completely different backtraces on the central website vs the website that originated the log message. The reason for this is 1) some messages rely on passing the backtrace via `env`, and 2) the env mutations that happen at line 163 in `base_store.rb`. This PR fixes the problem by `dup`ing `env` before deleting `:backtrace` from it (we still need to delete `:backtrace` from `env` because we don't want the backtrace to actually be part of `env`).