### PR TITLE
UX: Distinguish the value of the current env from the values of other envs

### DIFF
--- a/assets/javascript/client-app.js
+++ b/assets/javascript/client-app.js
@@ -160,7 +160,7 @@ var s=[],l=[],u=t.default.get("env_expandable_keys")||[]
 Object.keys(r).forEach((function(e){var t=r[e]
 if(null===t)s.push("null")
 else if("[object Array]"===Object.prototype.toString.call(t)){var p=""
-p=-1!==u.indexOf(e)&&!a&&-1===o.indexOf(e)&&t.length>3?"".concat(i(t[0]),', <a class="expand-list" data-key=').concat(e,">").concat(t.length-1," more</a>"):d(t),s.push("<tr><td>".concat(i(e),"</td><td>").concat(p,"</td></tr>"))}else if("object"===n(t))l.push(e)
+p=-1!==u.indexOf(e)&&!a&&-1===o.indexOf(e)&&t.length>3?"".concat(i(t[0]),', <a class="expand-list" data-key=').concat(e,">").concat(t.length-1," more</a>"):"".concat(i(t[0]),", ").concat(d(t.slice(1,t.length))),s.push("<tr><td>".concat(i(e),"</td><td>").concat(p,"</td></tr>"))}else if("object"===n(t))l.push(e)
 else if("time"===e&&"number"==typeof t){var f=moment(t).format(),m=c(t)
 s.push('<tr title="'.concat(f,'"><td>').concat(e,"</td><td>").concat(m,"</td></tr>"))}else s.push("<tr><td>".concat(i(e),"</td><td>").concat(i(t),"</td></tr>"))})),l.length>0&&l.forEach((function(t){var n=r[t]
 s.push("<tr><td></td><td><table>"),s.push("<td>".concat(i(t),"</td><td>").concat(e(n,!0),"</td>")),s.push("</table></td></tr>")}))
@@ -286,4 +286,4 @@ var t=Ember.HTMLBars.template({id:"QRu+EVou",block:'{"symbols":[],"statements":[
 e.default=t})),define("client-app/templates/show",["exports"],(function(e){Object.defineProperty(e,"__esModule",{value:!0}),e.default=void 0
 var t=Ember.HTMLBars.template({id:"Xt+M1cRV",block:'{"symbols":[],"statements":[[4,"link-to",null,[["route"],["index"]],{"statements":[[0,"Recent"]],"parameters":[]},null],[0,"\\n"],[7,"div",true],[10,"id","bottom-panel"],[10,"class","full"],[8],[0,"\\n  "],[1,[28,"message-info",null,[["currentMessage","showTitle","envChangedAction","currentEnvPosition","actionsInMenu"],[[24,["model"]],"true",[28,"action",[[23,0,[]],"envChanged"],null],[24,["envPosition"]],false]]],false],[0,"\\n"],[9],[0,"\\n"]],"hasEval":false}',meta:{moduleName:"client-app/templates/show.hbs"}})
 e.default=t})),define("client-app/config/environment",[],(function(){try{var e="client-app/config/environment",t=document.querySelector('meta[name="'+e+'"]').getAttribute("content"),n={default:JSON.parse(decodeURIComponent(t))}
-return Object.defineProperty(n,"__esModule",{value:!0}),n}catch(r){throw new Error('Could not read config from meta tag with name "'+e+'".')}})),runningTests||require("client-app/app").default.create({name:"client-app",version:"0.0.0+71fa880d"})
+return Object.defineProperty(n,"__esModule",{value:!0}),n}catch(r){throw new Error('Could not read config from meta tag with name "'+e+'".')}})),runningTests||require("client-app/app").default.create({name:"client-app",version:"0.0.0+63634ced"})

--- a/client-app/app/lib/utilities.js
+++ b/client-app/app/lib/utilities.js
@@ -150,7 +150,9 @@ export function buildHashString(hash, recurse, expanded = []) {
           v[0]
         )}, <a class="expand-list" data-key=${k}>${v.length - 1} more</a>`;
       } else {
-        valueHtml = buildArrayString(v);
+        valueHtml = `${escapeHtml(v[0])}, ${buildArrayString(
+          v.slice(1, v.length)
+        )}`;
       }
       buffer.push(`<tr><td>${escapeHtml(k)}</td><td>${valueHtml}</td></tr>`);
     } else if (typeof v === "object") {

--- a/client-app/package-lock.json
+++ b/client-app/package-lock.json
@@ -16270,7 +16270,7 @@
     },
     "http-errors": {
       "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+      "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "dev": true,
       "requires": {

--- a/client-app/tests/integration/components/env-tab-test.js
+++ b/client-app/tests/integration/components/env-tab-test.js
@@ -148,7 +148,7 @@ module("Integration | Component | env-tab", function(hooks) {
 
     assert.equal(
       defaultExpanded.children[1].textContent.trim(),
-      "[vvv1, vvv2]",
+      "vvv1, [vvv2]",
       "list is expanded by default when its length is 3 or less"
     );
 
@@ -165,7 +165,7 @@ module("Integration | Component | env-tab", function(hooks) {
     const expanded = find(".env-table tr");
     assert.equal(
       expanded.children[1].textContent.trim(),
-      "[value1, value2, value3, value4]",
+      "value1, [value2, value3, value4]",
       "expanded env keys shown correctly"
     );
 


### PR DESCRIPTION
Before this patch:

![image](https://user-images.githubusercontent.com/17474474/84284679-2f20e700-ab45-11ea-817f-1ac3708040c9.png)

After this patch:

![image](https://user-images.githubusercontent.com/17474474/84284724-3fd15d00-ab45-11ea-9226-373409f8f3ce.png)

Before this patch, it was difficult to tell which element of the `hostname` array belonged to the current env and which ones were coming from the remaining `env`s. Hopefully it'll become clearer with this patch.