### PR TITLE
Remove Redis 4.2 warnings

### DIFF
--- a/lib/logster/redis_store.rb
+++ b/lib/logster/redis_store.rb
@@ -342,7 +342,7 @@ module Logster
     def rate_limited?(ip_address, perform: false, limit: 60)
       key = ip_rate_limit_key(ip_address)
 
-      limited = @redis.exists(key)
+      limited = @redis.call([:exists, key])
       if Integer === limited
         limited = limited != 0
       end


### PR DESCRIPTION
Apps on Redis 4.2 and up will see a warning due to redis/redis-rb@3257527

Same as https://github.com/MiniProfiler/rack-mini-profiler/pull/450