### PR TITLE
UX: Turn severities below `Error` off by default

### DIFF
--- a/assets/javascript/client-app.js
+++ b/assets/javascript/client-app.js
@@ -1,5 +1,5 @@
 "use strict"
-define("client-app/app",["exports","client-app/resolver","ember-load-initializers","client-app/config/environment"],(function(e,t,n,r){function a(e){return(a="function"==typeof Symbol&&"symbol"==typeof Symbol.iterator?function(e){return typeof e}:function(e){return e&&"function"==typeof Symbol&&e.constructor===Symbol&&e!==Symbol.prototype?"symbol":typeof e})(e)}function o(e,t){if(!(e instanceof t))throw new TypeError("Cannot call a class as a function")}function s(e,t){return(s=Object.setPrototypeOf||function(e,t){return e.__proto__=t,e})(e,t)}function i(e){var t=function(){if("undefined"==typeof Reflect||!Reflect.construct)return!1
+define("client-app/app",["exports","client-app/resolver","ember-load-initializers","client-app/config/environment"],(function(e,t,n,r){function a(e){return(a="function"==typeof Symbol&&"symbol"==typeof Symbol.iterator?function(e){return typeof e}:function(e){return e&&"function"==typeof Symbol&&e.constructor===Symbol&&e!==Symbol.prototype?"symbol":typeof e})(e)}function o(e,t){if(!(e instanceof t))throw new TypeError("Cannot call a class as a function")}function i(e,t){return(i=Object.setPrototypeOf||function(e,t){return e.__proto__=t,e})(e,t)}function s(e){var t=function(){if("undefined"==typeof Reflect||!Reflect.construct)return!1
 if(Reflect.construct.sham)return!1
 if("function"==typeof Proxy)return!0
 try{return Date.prototype.toString.call(Reflect.construct(Date,[],(function(){}))),!0}catch(e){return!1}}()
@@ -9,38 +9,38 @@ n=Reflect.construct(r,arguments,a)}else n=r.apply(this,arguments)
 return l(this,n)}}function l(e,t){return!t||"object"!==a(t)&&"function"!=typeof t?u(e):t}function u(e){if(void 0===e)throw new ReferenceError("this hasn't been initialised - super() hasn't been called")
 return e}function c(e){return(c=Object.setPrototypeOf?Object.getPrototypeOf:function(e){return e.__proto__||Object.getPrototypeOf(e)})(e)}function d(e,t,n){return t in e?Object.defineProperty(e,t,{value:n,enumerable:!0,configurable:!0,writable:!0}):e[t]=n,e}Object.defineProperty(e,"__esModule",{value:!0}),e.default=void 0
 var p=function(e){(function(e,t){if("function"!=typeof t&&null!==t)throw new TypeError("Super expression must either be null or a function")
-e.prototype=Object.create(t&&t.prototype,{constructor:{value:e,writable:!0,configurable:!0}}),t&&s(e,t)})(a,Ember.Application)
-var n=i(a)
+e.prototype=Object.create(t&&t.prototype,{constructor:{value:e,writable:!0,configurable:!0}}),t&&i(e,t)})(a,Ember.Application)
+var n=s(a)
 function a(){var e
 o(this,a)
-for(var s=arguments.length,i=new Array(s),l=0;l<s;l++)i[l]=arguments[l]
-return d(u(e=n.call.apply(n,[this].concat(i))),"modulePrefix",r.default.modulePrefix),d(u(e),"podModulePrefix",r.default.podModulePrefix),d(u(e),"Resolver",t.default),e}return a}()
+for(var i=arguments.length,s=new Array(i),l=0;l<i;l++)s[l]=arguments[l]
+return d(u(e=n.call.apply(n,[this].concat(s))),"modulePrefix",r.default.modulePrefix),d(u(e),"podModulePrefix",r.default.podModulePrefix),d(u(e),"Resolver",t.default),e}return a}()
 e.default=p,(0,n.default)(p,r.default.modulePrefix)})),define("client-app/component-managers/glimmer",["exports","@glimmer/component/-private/ember-component-manager"],(function(e,t){Object.defineProperty(e,"__esModule",{value:!0}),Object.defineProperty(e,"default",{enumerable:!0,get:function(){return t.default}})})),define("client-app/components/actions-menu",["exports","client-app/lib/decorators"],(function(e,t){var n
 Object.defineProperty(e,"__esModule",{value:!0}),e.default=void 0
-var r,a,o,s,i,l,u=Ember.Component.extend((r=n={showMenu:!1,tagName:"span",outsideClickHandler:function(e){this.element&&!this.element.contains(e.target)&&this.element!==e.target&&(this.set("showMenu",!1),this.updateMenu())},updateMenu:function(){this.showMenu?this.addOutsideClickHandler():this.removeOutsideClickHandler()},addOutsideClickHandler:function(){document.addEventListener("click",this.outsideClickHandler)},removeOutsideClickHandler:function(){document.removeEventListener("click",this.outsideClickHandler)},willDestroyElement:function(){this._super.apply(this,arguments),this.removeOutsideClickHandler()},actions:{expandMenu:function(){this.toggleProperty("showMenu"),this.updateMenu()},share:function(){this.share()}}},a="outsideClickHandler",o=[t.bound],s=Object.getOwnPropertyDescriptor(n,"outsideClickHandler"),i=n,l={},Object.keys(s).forEach((function(e){l[e]=s[e]})),l.enumerable=!!l.enumerable,l.configurable=!!l.configurable,("value"in l||l.initializer)&&(l.writable=!0),l=o.slice().reverse().reduce((function(e,t){return t(r,a,e)||e}),l),i&&void 0!==l.initializer&&(l.value=l.initializer?l.initializer.call(i):void 0,l.initializer=void 0),void 0===l.initializer&&(Object.defineProperty(r,a,l),l=null),n))
+var r,a,o,i,s,l,u=Ember.Component.extend((r=n={showMenu:!1,tagName:"span",outsideClickHandler:function(e){this.element&&!this.element.contains(e.target)&&this.element!==e.target&&(this.set("showMenu",!1),this.updateMenu())},updateMenu:function(){this.showMenu?this.addOutsideClickHandler():this.removeOutsideClickHandler()},addOutsideClickHandler:function(){document.addEventListener("click",this.outsideClickHandler)},removeOutsideClickHandler:function(){document.removeEventListener("click",this.outsideClickHandler)},willDestroyElement:function(){this._super.apply(this,arguments),this.removeOutsideClickHandler()},actions:{expandMenu:function(){this.toggleProperty("showMenu"),this.updateMenu()},share:function(){this.share()}}},a="outsideClickHandler",o=[t.bound],i=Object.getOwnPropertyDescriptor(n,"outsideClickHandler"),s=n,l={},Object.keys(i).forEach((function(e){l[e]=i[e]})),l.enumerable=!!l.enumerable,l.configurable=!!l.configurable,("value"in l||l.initializer)&&(l.writable=!0),l=o.slice().reverse().reduce((function(e,t){return t(r,a,e)||e}),l),s&&void 0!==l.initializer&&(l.value=l.initializer?l.initializer.call(s):void 0,l.initializer=void 0),void 0===l.initializer&&(Object.defineProperty(r,a,l),l=null),n))
 e.default=u})),define("client-app/components/back-trace",["exports","client-app/lib/preload"],(function(e,t){function n(e,t){return function(e){if(Array.isArray(e))return e}(e)||function(e,t){if("undefined"==typeof Symbol||!(Symbol.iterator in Object(e)))return
 var n=[],r=!0,a=!1,o=void 0
-try{for(var s,i=e[Symbol.iterator]();!(r=(s=i.next()).done)&&(n.push(s.value),!t||n.length!==t);r=!0);}catch(l){a=!0,o=l}finally{try{r||null==i.return||i.return()}finally{if(a)throw o}}return n}(e,t)||function(e,t){if(!e)return
+try{for(var i,s=e[Symbol.iterator]();!(r=(i=s.next()).done)&&(n.push(i.value),!t||n.length!==t);r=!0);}catch(l){a=!0,o=l}finally{try{r||null==s.return||s.return()}finally{if(a)throw o}}return n}(e,t)||function(e,t){if(!e)return
 if("string"==typeof e)return r(e,t)
 var n=Object.prototype.toString.call(e).slice(8,-1)
 "Object"===n&&e.constructor&&(n=e.constructor.name)
 if("Map"===n||"Set"===n)return Array.from(e)
 if("Arguments"===n||/^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n))return r(e,t)}(e,t)||function(){throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method.")}()}function r(e,t){(null==t||t>e.length)&&(t=e.length)
 for(var n=0,r=new Array(t);n<t;n++)r[n]=e[n]
-return r}function a(e,t){return!(!e||!t||t.length>e.length)&&e.substring(0,t.length)===t}function o(){return t.default.get("backtrace_links_enabled")}function s(e){return e&&"/"!==e[e.length-1]?e+"/":e}function i(e){var t=e.repo,n=e.path,r=e.filename,a=e.lineNumber,o=e.commitSha,i=void 0===o?null:o,l=s(t)
-return/\/tree\//.test(l)||(l+="blob/",l+=i?"".concat(i,"/"):"master/"),l+=n+r,/^[0-9]+$/.test(a)&&(l+="#L".concat(a)),l}Object.defineProperty(e,"__esModule",{value:!0}),e.default=void 0
+return r}function a(e,t){return!(!e||!t||t.length>e.length)&&e.substring(0,t.length)===t}function o(){return t.default.get("backtrace_links_enabled")}function i(e){return e&&"/"!==e[e.length-1]?e+"/":e}function s(e){var t=e.repo,n=e.path,r=e.filename,a=e.lineNumber,o=e.commitSha,s=void 0===o?null:o,l=i(t)
+return/\/tree\//.test(l)||(l+="blob/",l+=s?"".concat(s,"/"):"master/"),l+=n+r,/^[0-9]+$/.test(a)&&(l+="#L".concat(a)),l}Object.defineProperty(e,"__esModule",{value:!0}),e.default=void 0
 var l=Ember.Component.extend({GithubURLForGem:function(e){var r=null
 if(!o())return r
-var s=n(e.match(/([^/]+)\/(.+\/)(.+):(\d+):.*/)||[],5),l=s[1],u=s[2],c=s[3],d=s[4],p=t.default.get("gems_data").filter((function(e){return a(l,"".concat(e.name,"-"))})).sortBy("name.length").reverse()[0]
-return p&&(r=i({repo:p.url,path:u,filename:c,lineNumber:d})),r},GithubURLForApp:function(e){var r=null
+var i=n(e.match(/([^/]+)\/(.+\/)(.+):(\d+):.*/)||[],5),l=i[1],u=i[2],c=i[3],d=i[4],p=t.default.get("gems_data").filter((function(e){return a(l,"".concat(e.name,"-"))})).sortBy("name.length").reverse()[0]
+return p&&(r=s({repo:p.url,path:u,filename:c,lineNumber:d})),r},GithubURLForApp:function(e){var r=null
 if(!o())return r
 var l=t.default.get("directories").filter((function(t){return a(e,t.path)})).sortBy("path.length").reverse()[0]
-if(l){var u,c,d,p=s(l.path),f=e.substring(p.length),m="",h=-1!==f.indexOf("/"),v=h?/(.+\/)(.+):(\d+)(:.*)/:/(.+):(\d+)(:.*)/
+if(l){var u,c,d,p=i(l.path),f=e.substring(p.length),m="",h=-1!==f.indexOf("/"),v=h?/(.+\/)(.+):(\d+)(:.*)/:/(.+):(\d+)(:.*)/
 if(h){var b=n(f.match(v)||[],5)
 m=b[1],u=b[2],c=b[3],d=b[4]}else{var g=n(f.match(v)||[],4)
 u=g[1],c=g[2],d=g[3]}if(u&&c&&d){var y=l.main_app?this.commitSha:null
-r=i({repo:l.url,path:m,filename:u,lineNumber:c,commitSha:y})}}return r},findGithubURL:function(e,n){var r=t.default.get("directories")||[],o=a(e,t.default.get("gems_dir")),s=r.some((function(t){return a(e,t.path)}))
-return o||!s?this.GithubURLForGem(n):this.GithubURLForApp(e)},commitSha:Ember.computed("env",(function(){var e=null
+r=s({repo:l.url,path:m,filename:u,lineNumber:c,commitSha:y})}}return r},findGithubURL:function(e,n){var r=t.default.get("directories")||[],o=a(e,t.default.get("gems_dir")),i=r.some((function(t){return a(e,t.path)}))
+return o||!i?this.GithubURLForGem(n):this.GithubURLForApp(e)},commitSha:Ember.computed("env",(function(){var e=null
 return Array.isArray(this.env)?e=this.env.map((function(e){return e.application_version})).filter((function(e){return e}))[0]:this.env&&(e=this.env.application_version),e||t.default.get("application_version")})),lines:Ember.computed("backtrace","commitSha",(function(){var e=this
 return this.backtrace&&0!==this.backtrace.length?this.backtrace.split("\n").map((function(n){var r=function(e){if(a(e,t.default.get("gems_dir"))){var n=t.default.get("gems_dir")
 return e.substring(n.length)}return e}(n)
@@ -70,16 +70,16 @@ this.navigate(t)}}})
 e.default=t})),define("client-app/components/panel-resizer",["exports","client-app/lib/decorators"],(function(e,t){var n
 function r(e,t,n,r,a){var o={}
 return Object.keys(r).forEach((function(e){o[e]=r[e]})),o.enumerable=!!o.enumerable,o.configurable=!!o.configurable,("value"in o||o.initializer)&&(o.writable=!0),o=n.slice().reverse().reduce((function(n,r){return r(e,t,n)||n}),o),a&&void 0!==o.initializer&&(o.value=o.initializer?o.initializer.call(a):void 0,o.initializer=void 0),void 0===o.initializer&&(Object.defineProperty(e,t,o),o=null),o}Object.defineProperty(e,"__esModule",{value:!0}),e.default=void 0
-var a=["touchmove","mousemove"],o=["touchend","mouseup"],s=["touchstart","mousedown"],i=Ember.Component.extend((r(n={resizing:!1,classNames:["divider"],divideView:function(e){var t=window.innerHeight,n=t-e
+var a=["touchmove","mousemove"],o=["touchend","mouseup"],i=["touchstart","mousedown"],s=Ember.Component.extend((r(n={resizing:!1,classNames:["divider"],divideView:function(e){var t=window.innerHeight,n=t-e
 e<100||e+170>t||(this.divider.style.bottom="".concat(n-5,"px"),this.events.trigger("panelResized",n))},performDrag:function(e){Ember.run.throttle(this,this.throttledPerformDrag,e,25)},throttledPerformDrag:function(e){this.resizing&&this.divideView(e.clientY||e.touches&&e.touches[0]&&e.touches[0].clientY)},endDrag:function(){var e=this,t=document.getElementById("overlay")
 t&&t.parentElement.removeChild(t),this.set("resizing",!1),localStorage&&(localStorage.logster_divider_bottom=parseInt(this.divider.style.bottom,10)),a.forEach((function(t){return document.removeEventListener(t,e.performDrag)})),o.forEach((function(t){return document.removeEventListener(t,e.endDrag)}))},dividerClickHandler:function(e){var t=this
 e.preventDefault()
 var n=document.createElement("DIV")
 n.id="overlay",document.body.appendChild(n),this.set("resizing",!0),a.forEach((function(e){return document.addEventListener(e,t.performDrag)})),o.forEach((function(e){return document.addEventListener(e,t.endDrag)}))},didInsertElement:function(){var e=this
-this.set("divider",document.querySelector(".divider")),s.forEach((function(t){e.divider.addEventListener(t,e.dividerClickHandler)})),Ember.run.scheduleOnce("afterRender",this,"initialDivideView")},initialDivideView:function(){var e=localStorage&&localStorage.logster_divider_bottom||300,t=window.innerHeight-parseInt(e,10)
+this.set("divider",document.querySelector(".divider")),i.forEach((function(t){e.divider.addEventListener(t,e.dividerClickHandler)})),Ember.run.scheduleOnce("afterRender",this,"initialDivideView")},initialDivideView:function(){var e=localStorage&&localStorage.logster_divider_bottom||300,t=window.innerHeight-parseInt(e,10)
 this.divideView(t)},willDestroyElement:function(){var e=this
-s.forEach((function(t){return e.divider.removeEventListener(t,e.dividerClickHandler)}))}},"performDrag",[t.bound],Object.getOwnPropertyDescriptor(n,"performDrag"),n),r(n,"endDrag",[t.bound],Object.getOwnPropertyDescriptor(n,"endDrag"),n),r(n,"dividerClickHandler",[t.bound],Object.getOwnPropertyDescriptor(n,"dividerClickHandler"),n),n))
-e.default=i})),define("client-app/components/patterns-list",["exports","client-app/models/pattern-item","client-app/lib/utilities"],(function(e,t,n){function r(e){return function(e){if(Array.isArray(e))return a(e)}(e)||function(e){if("undefined"!=typeof Symbol&&Symbol.iterator in Object(e))return Array.from(e)}(e)||function(e,t){if(!e)return
+i.forEach((function(t){return e.divider.removeEventListener(t,e.dividerClickHandler)}))}},"performDrag",[t.bound],Object.getOwnPropertyDescriptor(n,"performDrag"),n),r(n,"endDrag",[t.bound],Object.getOwnPropertyDescriptor(n,"endDrag"),n),r(n,"dividerClickHandler",[t.bound],Object.getOwnPropertyDescriptor(n,"dividerClickHandler"),n),n))
+e.default=s})),define("client-app/components/patterns-list",["exports","client-app/models/pattern-item","client-app/lib/utilities"],(function(e,t,n){function r(e){return function(e){if(Array.isArray(e))return a(e)}(e)||function(e){if("undefined"!=typeof Symbol&&Symbol.iterator in Object(e))return Array.from(e)}(e)||function(e,t){if(!e)return
 if("string"==typeof e)return a(e,t)
 var n=Object.prototype.toString.call(e).slice(8,-1)
 "Object"===n&&e.constructor&&(n=e.constructor.name)
@@ -107,20 +107,19 @@ var n=Ember.Component.extend({didInsertElement:function(){Ember.run.later(this,t
 if(n){var r=(0,t.formatTime)(n)
 r!==e.innerText&&(e.innerText=r)}})),Ember.run.later(this,this.updateTimes,6e4)}})
 e.default=n})),define("client-app/controllers/index",["exports","client-app/lib/utilities","client-app/lib/preload"],(function(e,t,n){Object.defineProperty(e,"__esModule",{value:!0}),e.default=void 0
-var r=Ember.Controller.extend({showDebug:!0,showInfo:!0,showWarn:!0,showErr:!0,showFatal:!0,search:"",queryParams:["search"],showSettings:Ember.computed((function(){return n.default.get("patterns_enabled")})),resizePanels:function(e){var t=document.getElementById("bottom-panel"),n=document.getElementById("top-panel")
+var r=Ember.Controller.extend({showDebug:!1,showInfo:!1,showWarn:!1,showErr:!0,showFatal:!0,search:"",queryParams:["search"],showSettings:Ember.computed((function(){return n.default.get("patterns_enabled")})),resizePanels:function(e){var t=document.getElementById("bottom-panel"),n=document.getElementById("top-panel")
 t.style.height="".concat(e-13,"px"),n.style.bottom="".concat(e+12,"px")},actionsInMenu:Ember.computed((function(){return this.site.isMobile})),actions:{expandMessage:function(e){e.expand()},selectRowAction:function(e){var t=arguments.length>1&&void 0!==arguments[1]?arguments[1]:{}
 this.model.selectRow(e,t)},tabChangedAction:function(e){this.model.tabChanged(e)},showMoreBefore:function(){this.model.showMoreBefore()},loadMore:function(){return this.model.loadMore()},clear:function(){var e=this
 confirm("Clear the logs?\n\nCancel = No, OK = Clear")&&(0,t.ajax)("/clear",{type:"POST"}).then((function(){e.model.reload()}))},removeMessage:function(e){var t=this.model.currentRow.group?this.model.currentRow:null,n=this.model.rows,r=t?n.indexOf(t):n.indexOf(e)
 e.destroy(),e.set("selected",!1),this.model.set("total",this.model.total-1)
 var a=!1,o=0
 t?(o=t.messages.indexOf(e),t.messages.removeObject(e),o=Math.min(o,t.messages.length-1),0===t.messages.length&&(n.removeObject(t),a=!0)):(n.removeObject(e),a=!0),a?r>0?this.model.selectRow(n[r-1]):this.model.total>0?this.model.selectRow(n[0]):this.model.reload():t&&this.model.selectRow(n[r],{messageIndex:o})},solveMessage:function(e){this.model.solve(e)},groupedMessageChangedAction:function(e){this.model.groupedMessageChanged(e)},envChangedAction:function(e){this.model.envChanged(e)},updateFilter:function(e){var t=this
-this.toggleProperty(e)
-var n=[];["Debug","Info","Warn","Err","Fatal"].forEach((function(e,r){t.get("show".concat(e))&&n.push(r)})),n.push(5),this.model.set("filter",n),this.model.reload().then((function(){return t.model.updateSelectedRow()}))},updateSearch:function(e){e!==this.search&&(e&&1===e.length||Ember.run.debounce(this,this.doSearch,e,250))}},doSearch:function(e){var t=this
+this.toggleProperty(e),this.model.set(e,this[e]),this.model.reload().then((function(){return t.model.updateSelectedRow()}))},updateSearch:function(e){e!==this.search&&(e&&1===e.length||Ember.run.debounce(this,this.doSearch,e,250))}},doSearch:function(e){var t=this
 this.model.set("search",e),this.model.reload().then((function(){return t.model.updateSelectedRow()}))}})
 e.default=r})),define("client-app/controllers/show",["exports"],(function(e){Object.defineProperty(e,"__esModule",{value:!0}),e.default=void 0
 var t=Ember.Controller.extend({envPosition:0,actions:{protect:function(){this.get("model").protect()},unprotect:function(){this.get("model").unprotect()},envChanged:function(e){this.set("envPosition",e)}}})
-e.default=t})),define("client-app/helpers/app-version",["exports","client-app/config/environment","ember-cli-app-version/utils/regexp"],(function(e,t,n){function r(e){var r=arguments.length>1&&void 0!==arguments[1]?arguments[1]:{},a=t.default.APP.version,o=r.versionOnly||r.hideSha,s=r.shaOnly||r.hideVersion,i=null
-return o&&(r.showExtended&&(i=a.match(n.versionExtendedRegExp)),i||(i=a.match(n.versionRegExp))),s&&(i=a.match(n.shaRegExp)),i?i[0]:a}Object.defineProperty(e,"__esModule",{value:!0}),e.appVersion=r,e.default=void 0
+e.default=t})),define("client-app/helpers/app-version",["exports","client-app/config/environment","ember-cli-app-version/utils/regexp"],(function(e,t,n){function r(e){var r=arguments.length>1&&void 0!==arguments[1]?arguments[1]:{},a=t.default.APP.version,o=r.versionOnly||r.hideSha,i=r.shaOnly||r.hideVersion,s=null
+return o&&(r.showExtended&&(s=a.match(n.versionExtendedRegExp)),s||(s=a.match(n.versionRegExp))),i&&(s=a.match(n.shaRegExp)),s?s[0]:a}Object.defineProperty(e,"__esModule",{value:!0}),e.appVersion=r,e.default=void 0
 var a=Ember.Helper.helper(r)
 e.default=a})),define("client-app/helpers/logster-url",["exports","client-app/lib/preload"],(function(e,t){function n(e){var n=e[0]
 return"/"!==n[0]&&(n="/".concat(n)),(0,t.getRootPath)()+n}Object.defineProperty(e,"__esModule",{value:!0}),e.logsterUrl=n,e.default=void 0
@@ -129,10 +128,10 @@ e.default=r})),define("client-app/helpers/or",["exports"],(function(e){function 
 var n=Ember.Helper.helper(t)
 e.default=n})),define("client-app/initializers/app-init",["exports","client-app/lib/utilities","client-app/lib/preload"],(function(e,t,n){Object.defineProperty(e,"__esModule",{value:!0}),e.initialize=a,e.default=void 0
 var r=["component","route"]
-function a(e){var a,o,s=e.resolveRegistration("config:environment");(0,n.setRootPath)(s.rootURL.replace(/\/$/,"")),"development"===s.environment&&(e.deferReadiness(),(0,t.ajax)("/development-preload.json").then((function(e){document.getElementById("preloaded-data").setAttribute("data-preloaded",JSON.stringify(e))})).catch((function(e){return console.error("Fetching preload data failed.",e)})).finally((function(){return e.advanceReadiness()}))),moment.updateLocale("en",{relativeTime:{future:"in %s",past:"%s ago",s:"secs",m:"a min",mm:"%d mins",h:"an hr",hh:"%d hrs",d:"a day",dd:"%d days",M:"a mth",MM:"%d mths",y:"a yr",yy:"%d yrs"}}),["","webkit","ms","moz","ms"].forEach((function(e){var t=e+(""===e?"hidden":"Hidden")
+function a(e){var a,o,i=e.resolveRegistration("config:environment");(0,n.setRootPath)(i.rootURL.replace(/\/$/,"")),"development"===i.environment&&(e.deferReadiness(),(0,t.ajax)("/development-preload.json").then((function(e){document.getElementById("preloaded-data").setAttribute("data-preloaded",JSON.stringify(e))})).catch((function(e){return console.error("Fetching preload data failed.",e)})).finally((function(){return e.advanceReadiness()}))),moment.updateLocale("en",{relativeTime:{future:"in %s",past:"%s ago",s:"secs",m:"a min",mm:"%d mins",h:"an hr",hh:"%d hrs",d:"a day",dd:"%d days",M:"a mth",MM:"%d mths",y:"a yr",yy:"%d yrs"}}),["","webkit","ms","moz","ms"].forEach((function(e){var t=e+(""===e?"hidden":"Hidden")
 void 0===document[t]||a||(a=t,o=e+"visibilitychange")})),(0,t.updateHiddenProperty)(a),document.addEventListener(o,(function(){(0,t.resetTitleCount)()}),!1),e.register("events:main",Ember.Object.extend(Ember.Evented).create(),{instantiate:!1}),r.forEach((function(t){return e.inject(t,"events","events:main")}))
-var i=/mobile/i.test(navigator.userAgent)&&!/iPad/.test(navigator.userAgent)
-i&&document.body.classList.add("mobile"),e.register("site:main",{isMobile:i},{instantiate:!1}),e.inject("controller","site","site:main")}var o={initialize:a}
+var s=/mobile/i.test(navigator.userAgent)&&!/iPad/.test(navigator.userAgent)
+s&&document.body.classList.add("mobile"),e.register("site:main",{isMobile:s},{instantiate:!1}),e.inject("controller","site","site:main")}var o={initialize:a}
 e.default=o})),define("client-app/initializers/app-version",["exports","ember-cli-app-version/initializer-factory","client-app/config/environment"],(function(e,t,n){var r,a
 Object.defineProperty(e,"__esModule",{value:!0}),e.default=void 0,n.default.APP&&(r=n.default.APP.name,a=n.default.APP.version)
 var o={name:"App Version",initialize:(0,t.default)(r,a)}
@@ -152,35 +151,42 @@ return{get:function(){return this[a]?this[a]:(this.set(a,r.bind(this)),this[a])}
 Em.set(n,e,t)},e.uninitialize=function(){r=!1},e.default=void 0
 var t,n={},r=!1
 function a(){var e=document.getElementById("preloaded-data").dataset;(n=JSON.parse(e.preloaded)).rootPath=t,r=!0}var o={get:function(e){return r||a(),Em.get(n,e)}}
-e.default=o})),define("client-app/lib/utilities",["exports","client-app/lib/preload"],(function(e,t){function n(e){return(n="function"==typeof Symbol&&"symbol"==typeof Symbol.iterator?function(e){return typeof e}:function(e){return e&&"function"==typeof Symbol&&e.constructor===Symbol&&e!==Symbol.prototype?"symbol":typeof e})(e)}Object.defineProperty(e,"__esModule",{value:!0}),e.escapeHtml=i,e.ajax=l,e.preloadOrAjax=function(e,n){var r=t.default.get(e.replace(".json",""))
+e.default=o})),define("client-app/lib/utilities",["exports","client-app/lib/preload"],(function(e,t){function n(e){return(n="function"==typeof Symbol&&"symbol"==typeof Symbol.iterator?function(e){return typeof e}:function(e){return e&&"function"==typeof Symbol&&e.constructor===Symbol&&e!==Symbol.prototype?"symbol":typeof e})(e)}Object.defineProperty(e,"__esModule",{value:!0}),e.escapeHtml=s,e.ajax=l,e.preloadOrAjax=function(e,n){var r=t.default.get(e.replace(".json",""))
 return r?Ember.RSVP.resolve(r):l(e,n)},e.updateHiddenProperty=function(e){r=e},e.isHidden=u,e.increaseTitleCount=function(e){if(!u())return
 a=a||document.title,o=o||0,o+=e,document.title="".concat(a," (").concat(o,")")},e.resetTitleCount=function(){o=0,document.title=a||document.title},e.formatTime=c,e.buildArrayString=d,e.buildHashString=function e(r,a){var o=arguments.length>2&&void 0!==arguments[2]?arguments[2]:[]
 if(!r)return""
-var s=[],l=[],u=t.default.get("env_expandable_keys")||[]
+var i=[],l=[],u=t.default.get("env_expandable_keys")||[]
 Object.keys(r).forEach((function(e){var t=r[e]
-if(null===t)s.push("null")
+if(null===t)i.push("null")
 else if("[object Array]"===Object.prototype.toString.call(t)){var p=""
-p=-1!==u.indexOf(e)&&!a&&-1===o.indexOf(e)&&t.length>3?"".concat(i(t[0]),', <a class="expand-list" data-key=').concat(e,">").concat(t.length-1," more</a>"):"".concat(i(t[0]),", ").concat(d(t.slice(1,t.length))),s.push("<tr><td>".concat(i(e),"</td><td>").concat(p,"</td></tr>"))}else if("object"===n(t))l.push(e)
+p=-1!==u.indexOf(e)&&!a&&-1===o.indexOf(e)&&t.length>3?"".concat(s(t[0]),', <a class="expand-list" data-key=').concat(e,">").concat(t.length-1," more</a>"):"".concat(s(t[0]),", ").concat(d(t.slice(1,t.length))),i.push("<tr><td>".concat(s(e),"</td><td>").concat(p,"</td></tr>"))}else if("object"===n(t))l.push(e)
 else if("time"===e&&"number"==typeof t){var f=moment(t).format(),m=c(t)
-s.push('<tr title="'.concat(f,'"><td>').concat(e,"</td><td>").concat(m,"</td></tr>"))}else s.push("<tr><td>".concat(i(e),"</td><td>").concat(i(t),"</td></tr>"))})),l.length>0&&l.forEach((function(t){var n=r[t]
-s.push("<tr><td></td><td><table>"),s.push("<td>".concat(i(t),"</td><td>").concat(e(n,!0),"</td>")),s.push("</table></td></tr>")}))
+i.push('<tr title="'.concat(f,'"><td>').concat(e,"</td><td>").concat(m,"</td></tr>"))}else i.push("<tr><td>".concat(s(e),"</td><td>").concat(s(t),"</td></tr>"))})),l.length>0&&l.forEach((function(t){var n=r[t]
+i.push("<tr><td></td><td><table>"),i.push("<td>".concat(s(t),"</td><td>").concat(e(n,!0),"</td>")),i.push("</table></td></tr>")}))
 var p=a?"":"env-table"
-return"<table class='".concat(p,"'>").concat(s.join("\n"),"</table>")},e.clone=function(e){var t={}
+return"<table class='".concat(p,"'>").concat(i.join("\n"),"</table>")},e.clone=function(e){var t={}
 return Object.keys(e).forEach((function(n){t[n]=e[n]})),t}
-var r,a,o,s={"&":"&amp;","<":"&lt;",">":"&gt;",'"':"&quot;","'":"&#39;","/":"&#x2F;"}
-function i(e){return String(e).replace(/[&<>"'/]/g,(function(e){return s[e]}))}function l(e,n){return new Ember.RSVP.Promise((function(r,a){n=n||{}
+var r,a,o,i={"&":"&amp;","<":"&lt;",">":"&gt;",'"':"&quot;","'":"&#39;","/":"&#x2F;"}
+function s(e){return String(e).replace(/[&<>"'/]/g,(function(e){return i[e]}))}function l(e,n){return new Ember.RSVP.Promise((function(r,a){n=n||{}
 var o=new XMLHttpRequest
-if(e=(0,t.getRootPath)()+e,n.data)for(var s in n.data){var i=-1===e.indexOf("?")?"?":"&"
-e+=i,e+="".concat(s,"=").concat(encodeURIComponent(n.data[s]))}if(o.open(n.method||n.type||"GET",e),o.setRequestHeader("X-SILENCE-LOGGER",!0),n.headers)for(var l in n.headers)o.setRequestHeader(l,n.headers[l])
+if(e=(0,t.getRootPath)()+e,n.data)for(var i in n.data){var s=-1===e.indexOf("?")?"?":"&"
+e+=s,e+="".concat(i,"=").concat(encodeURIComponent(n.data[i]))}if(o.open(n.method||n.type||"GET",e),o.setRequestHeader("X-SILENCE-LOGGER",!0),n.headers)for(var l in n.headers)o.setRequestHeader(l,n.headers[l])
 o.onreadystatechange=function(){if(4===o.readyState){var e=o.status
 if(e>=200&&e<300||304===e){var t=o.getResponseHeader("Content-Type"),n=o.responseText;/\bjson\b/.test(t)&&(n=JSON.parse(n)),r(n)}else a(o)}},o.send()}))}function u(){return void 0!==r?document[r]:!document.hasFocus}function c(e){var t=moment(e),n=moment()
 return t.diff(n.startOf("day"))>0?t.format("h:mm a"):t.diff(n.startOf("week"))>0?t.format("dd h:mm a"):t.diff(n.startOf("year"))>0?t.format("D MMM h:mm a"):t.format("D MMM YY")}function d(e){var t=[]
-return e.forEach((function(e){null===e?t.push("null"):"[object Array]"===Object.prototype.toString.call(e)?t.push(d(e)):t.push(i(e.toString()))})),"["+t.join(", ")+"]"}})),define("client-app/models/group",["exports","client-app/models/message","client-app/lib/utilities"],(function(e,t,n){Object.defineProperty(e,"__esModule",{value:!0}),e.default=void 0
+return e.forEach((function(e){null===e?t.push("null"):"[object Array]"===Object.prototype.toString.call(e)?t.push(d(e)):t.push(s(e.toString()))})),"["+t.join(", ")+"]"}})),define("client-app/models/group",["exports","client-app/models/message","client-app/lib/utilities"],(function(e,t,n){Object.defineProperty(e,"__esModule",{value:!0}),e.default=void 0
 var r=Ember.Object.extend({selected:!1,showCount:!0,key:Ember.computed.reads("regex"),displayMessage:Ember.computed.reads("messages.firstObject.message"),init:function(){this._super.apply(this,arguments)
 var e=this.messages.map((function(e){return t.default.create(e)}))
 this.set("messages",e)},glyph:Ember.computed((function(){return"clone"})),prefix:Ember.computed((function(){return"far"})),solveAll:function(){return(0,n.ajax)("/solve-group",{type:"POST",data:{regex:this.regex}})}})
-e.default=r})),define("client-app/models/message-collection",["exports","client-app/lib/utilities","client-app/models/message","client-app/models/group"],(function(e,t,n,r){Object.defineProperty(e,"__esModule",{value:!0}),e.default=void 0
-var a=[0,1,2,3,4,5],o=Ember.Object.extend({total:0,rows:null,currentRow:null,currentTab:null,currentEnvPosition:0,currentGroupedMessagesPosition:0,init:function(){this._super.apply(this,arguments),this.setProperties({filter:a,search:"",rows:Ember.A()})},currentMessage:Ember.computed("currentRow","currentGroupedMessagesPosition",(function(){var e=this.currentRow,t=this.currentGroupedMessagesPosition
+e.default=r})),define("client-app/models/message-collection",["exports","client-app/lib/utilities","client-app/models/message","client-app/models/group"],(function(e,t,n,r){function a(e,t){(null==t||t>e.length)&&(t=e.length)
+for(var n=0,r=new Array(t);n<t;n++)r[n]=e[n]
+return r}Object.defineProperty(e,"__esModule",{value:!0}),e.default=e.SEVERITIES=void 0
+var o=["Debug","Info","Warn","Err","Fatal"]
+e.SEVERITIES=o
+var i,s=Ember.Object.extend({total:0,rows:null,currentRow:null,currentTab:null,currentEnvPosition:0,currentGroupedMessagesPosition:0,filter:Ember.computed.apply(void 0,(i=o.map((function(e){return"show".concat(e)})),function(e){if(Array.isArray(e))return a(e)}(i)||function(e){if("undefined"!=typeof Symbol&&Symbol.iterator in Object(e))return Array.from(e)}(i)||function(e,t){if(e){if("string"==typeof e)return a(e,t)
+var n=Object.prototype.toString.call(e).slice(8,-1)
+return"Object"===n&&e.constructor&&(n=e.constructor.name),"Map"===n||"Set"===n?Array.from(e):"Arguments"===n||/^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)?a(e,t):void 0}}(i)||function(){throw new TypeError("Invalid attempt to spread non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method.")}()).concat([function(){var e=this,t=[]
+return o.forEach((function(n,r){e["show".concat(n)]&&t.push(r)})),t.push(5),t}])),init:function(){this._super.apply(this,arguments),this.setProperties({search:"",rows:Ember.A()})},currentMessage:Ember.computed("currentRow","currentGroupedMessagesPosition",(function(){var e=this.currentRow,t=this.currentGroupedMessagesPosition
 return e&&e.group?e.messages[t]:e})),solve:function(e){var t=this
 e.solve().then((function(){t.reload()}))},selectRow:function(e){var t=arguments.length>1&&void 0!==arguments[1]?arguments[1]:{},n=this.currentRow
 n&&n.set("selected",!1),e.set("selected",!0)
@@ -208,7 +214,7 @@ return this.search&&this.search.length>0||e&&e.length<6})),moreBefore:Ember.comp
 this.load({before:r,knownGroups:a}).then((function(t){return e.updateCanLoadMore(t)}))},regexSearch:Ember.computed("search",(function(){var e=this.search
 if(e&&e.length>2&&"/"===e[0]){var t=e.match(/\/(.*)\/(.*)/)
 if(t&&3===t.length)try{return new RegExp(t[1],t[2])}catch(n){}}return null})),toObjects:function(e){return e.map((function(e){return e.group?r.default.create(e):n.default.create(e)}))}})
-e.default=o})),define("client-app/models/message",["exports","client-app/lib/utilities","client-app/lib/preload"],(function(e,t,n){Object.defineProperty(e,"__esModule",{value:!0}),e.default=void 0
+e.default=s})),define("client-app/models/message",["exports","client-app/lib/utilities","client-app/lib/preload"],(function(e,t,n){Object.defineProperty(e,"__esModule",{value:!0}),e.default=void 0
 var r=Em.Object.extend({MAX_LEN:200,fetchEnv:function(){var e=this
 return(0,t.ajax)("/fetch-env/".concat(this.key,".json")).then((function(t){return e.set("env",t)}))},expand:function(){this.set("expanded",!0)},solve:function(){return(0,t.ajax)("/solve/".concat(this.key),{type:"PUT"})},destroy:function(){return(0,t.ajax)("/message/".concat(this.key),{type:"DELETE"})},protect:function(){return this.set("protected",!0),(0,t.ajax)("/protect/".concat(this.key),{type:"PUT"})},unprotect:function(){return this.set("protected",!1),(0,t.ajax)("/unprotect/".concat(this.key),{type:"DELETE"})},showCount:Ember.computed("count",(function(){return this.count>1})),hasMore:Ember.computed("message","expanded",(function(){return!this.expanded&&this.message.length>this.MAX_LEN})),shareUrl:Ember.computed("key",(function(){return"".concat((0,n.getRootPath)(),"/show/").concat(this.key)})),displayMessage:Ember.computed("message","expanded",(function(){var e=this.message
 return!this.expanded&&this.message.length>this.MAX_LEN&&(e=this.message.substr(0,this.MAX_LEN)),e})),updateFromObject:function(e){this.set("count",e.get("count"))},canSolve:Ember.computed("env.{application_version,length}",(function(){return(Array.isArray(this.env)?this.env.map((function(e){return e.application_version})).compact().join(""):this.env&&this.env.application_version)&&this.backtrace&&this.backtrace.length>0})),rowClass:Ember.computed("severity",(function(){switch(this.get("severity")){case 0:return"debug"
@@ -236,25 +242,25 @@ try{return Date.prototype.toString.call(Reflect.construct(Date,[],(function(){})
 return function(){var n,r=l(e)
 if(t){var a=l(this).constructor
 n=Reflect.construct(r,arguments,a)}else n=r.apply(this,arguments)
-return s(this,n)}}function s(e,t){return!t||"object"!==n(t)&&"function"!=typeof t?i(e):t}function i(e){if(void 0===e)throw new ReferenceError("this hasn't been initialised - super() hasn't been called")
+return i(this,n)}}function i(e,t){return!t||"object"!==n(t)&&"function"!=typeof t?s(e):t}function s(e){if(void 0===e)throw new ReferenceError("this hasn't been initialised - super() hasn't been called")
 return e}function l(e){return(l=Object.setPrototypeOf?Object.getPrototypeOf:function(e){return e.__proto__||Object.getPrototypeOf(e)})(e)}function u(e,t,n){return t in e?Object.defineProperty(e,t,{value:n,enumerable:!0,configurable:!0,writable:!0}):e[t]=n,e}Object.defineProperty(e,"__esModule",{value:!0}),e.default=void 0
 var c=function(e){(function(e,t){if("function"!=typeof t&&null!==t)throw new TypeError("Super expression must either be null or a function")
-e.prototype=Object.create(t&&t.prototype,{constructor:{value:e,writable:!0,configurable:!0}}),t&&a(e,t)})(s,Ember.Router)
-var n=o(s)
-function s(){var e
-r(this,s)
+e.prototype=Object.create(t&&t.prototype,{constructor:{value:e,writable:!0,configurable:!0}}),t&&a(e,t)})(i,Ember.Router)
+var n=o(i)
+function i(){var e
+r(this,i)
 for(var a=arguments.length,o=new Array(a),l=0;l<a;l++)o[l]=arguments[l]
-return u(i(e=n.call.apply(n,[this].concat(o))),"location",t.default.locationType),u(i(e),"rootURL",t.default.rootURL),e}return s}()
+return u(s(e=n.call.apply(n,[this].concat(o))),"location",t.default.locationType),u(s(e),"rootURL",t.default.rootURL),e}return i}()
 e.default=c,c.map((function(){this.route("index",{path:"/"}),this.route("show",{path:"/show/:id"}),this.route("settings")}))})),define("client-app/routes/index",["exports","client-app/models/message-collection","client-app/lib/utilities"],(function(e,t,n){Object.defineProperty(e,"__esModule",{value:!0}),e.default=void 0
-var r=Ember.Route.extend({model:function(){return t.default.create()},setupController:function(e,t){this._super(e,t),t.reload()
-var r=0,a=1
-this.refreshInterval=setInterval((function(){if(!t.loading){r+=1
-var e=(0,n.isHidden)(),o=!e
-e&&r%a==0&&(o=!0,a<20&&a++),o&&(t.loadMore(),e||(a=1))}}),3e3),this.events.on("panelResized",(function(t){e.resizePanels(t)}))},deactivate:function(){clearInterval(this.refreshInterval)}})
+var r=Ember.Route.extend({model:function(){return t.default.create()},setupController:function(e,r){this._super(e,r),t.SEVERITIES.forEach((function(t){return r.set("show".concat(t),e["show".concat(t)])})),r.reload()
+var a=0,o=1
+this.refreshInterval=setInterval((function(){if(!r.loading){a+=1
+var e=(0,n.isHidden)(),t=!e
+e&&a%o==0&&(t=!0,o<20&&o++),t&&(r.loadMore(),e||(o=1))}}),3e3),this.events.on("panelResized",(function(t){e.resizePanels(t)}))},deactivate:function(){clearInterval(this.refreshInterval)}})
 e.default=r})),define("client-app/routes/settings",["exports","client-app/lib/utilities","client-app/models/pattern-item"],(function(e,t,n){Object.defineProperty(e,"__esModule",{value:!0}),e.default=void 0
 var r=Ember.Route.extend({model:function(){return(0,t.ajax)("/settings.json")},setupController:function(e,t){this._super.apply(this,arguments)
-var r=t.suppression,a=r.filter((function(e){return e.hard})).map((function(e){return n.default.create(e)})),o=r.reject((function(e){return e.hard})).map((function(e){return n.default.create(e)})),s=t.grouping.map((function(e){return n.default.create(e)})),i=a.length>0
-e.setProperties({showCodedSuppression:i,codedSuppression:a,customSuppression:o,grouping:s})}})
+var r=t.suppression,a=r.filter((function(e){return e.hard})).map((function(e){return n.default.create(e)})),o=r.reject((function(e){return e.hard})).map((function(e){return n.default.create(e)})),i=t.grouping.map((function(e){return n.default.create(e)})),s=a.length>0
+e.setProperties({showCodedSuppression:s,codedSuppression:a,customSuppression:o,grouping:i})}})
 e.default=r})),define("client-app/routes/show",["exports","client-app/models/message","client-app/lib/utilities"],(function(e,t,n){Object.defineProperty(e,"__esModule",{value:!0}),e.default=void 0
 var r=Ember.Route.extend({model:function(e){return(0,n.preloadOrAjax)("/show/"+e.id+".json")},setupController:function(e,n){this._super.apply(this,arguments),e.set("model",t.default.create(n))}})
 e.default=r})),define("client-app/templates/application",["exports"],(function(e){Object.defineProperty(e,"__esModule",{value:!0}),e.default=void 0
@@ -286,4 +292,4 @@ var t=Ember.HTMLBars.template({id:"QRu+EVou",block:'{"symbols":[],"statements":[
 e.default=t})),define("client-app/templates/show",["exports"],(function(e){Object.defineProperty(e,"__esModule",{value:!0}),e.default=void 0
 var t=Ember.HTMLBars.template({id:"Xt+M1cRV",block:'{"symbols":[],"statements":[[4,"link-to",null,[["route"],["index"]],{"statements":[[0,"Recent"]],"parameters":[]},null],[0,"\\n"],[7,"div",true],[10,"id","bottom-panel"],[10,"class","full"],[8],[0,"\\n  "],[1,[28,"message-info",null,[["currentMessage","showTitle","envChangedAction","currentEnvPosition","actionsInMenu"],[[24,["model"]],"true",[28,"action",[[23,0,[]],"envChanged"],null],[24,["envPosition"]],false]]],false],[0,"\\n"],[9],[0,"\\n"]],"hasEval":false}',meta:{moduleName:"client-app/templates/show.hbs"}})
 e.default=t})),define("client-app/config/environment",[],(function(){try{var e="client-app/config/environment",t=document.querySelector('meta[name="'+e+'"]').getAttribute("content"),n={default:JSON.parse(decodeURIComponent(t))}
-return Object.defineProperty(n,"__esModule",{value:!0}),n}catch(r){throw new Error('Could not read config from meta tag with name "'+e+'".')}})),runningTests||require("client-app/app").default.create({name:"client-app",version:"0.0.0+63634ced"})
+return Object.defineProperty(n,"__esModule",{value:!0}),n}catch(r){throw new Error('Could not read config from meta tag with name "'+e+'".')}})),runningTests||require("client-app/app").default.create({name:"client-app",version:"0.0.0+d01416df"})

--- a/assets/javascript/client-app.js
+++ b/assets/javascript/client-app.js
@@ -107,14 +107,14 @@ var n=Ember.Component.extend({didInsertElement:function(){Ember.run.later(this,t
 if(n){var r=(0,t.formatTime)(n)
 r!==e.innerText&&(e.innerText=r)}})),Ember.run.later(this,this.updateTimes,6e4)}})
 e.default=n})),define("client-app/controllers/index",["exports","client-app/lib/utilities","client-app/lib/preload"],(function(e,t,n){Object.defineProperty(e,"__esModule",{value:!0}),e.default=void 0
-var r=Ember.Controller.extend({showDebug:!1,showInfo:!1,showWarn:!1,showErr:!0,showFatal:!0,search:"",queryParams:["search"],showSettings:Ember.computed((function(){return n.default.get("patterns_enabled")})),resizePanels:function(e){var t=document.getElementById("bottom-panel"),n=document.getElementById("top-panel")
+var r=Ember.Controller.extend({showDebug:(0,t.getLocalStorage)("showDebug",!1),showInfo:(0,t.getLocalStorage)("showInfo",!1),showWarn:(0,t.getLocalStorage)("showWarn",!1),showErr:(0,t.getLocalStorage)("showErr",!0),showFatal:(0,t.getLocalStorage)("showFatal",!0),search:"",queryParams:["search"],showSettings:Ember.computed((function(){return n.default.get("patterns_enabled")})),resizePanels:function(e){var t=document.getElementById("bottom-panel"),n=document.getElementById("top-panel")
 t.style.height="".concat(e-13,"px"),n.style.bottom="".concat(e+12,"px")},actionsInMenu:Ember.computed((function(){return this.site.isMobile})),actions:{expandMessage:function(e){e.expand()},selectRowAction:function(e){var t=arguments.length>1&&void 0!==arguments[1]?arguments[1]:{}
 this.model.selectRow(e,t)},tabChangedAction:function(e){this.model.tabChanged(e)},showMoreBefore:function(){this.model.showMoreBefore()},loadMore:function(){return this.model.loadMore()},clear:function(){var e=this
 confirm("Clear the logs?\n\nCancel = No, OK = Clear")&&(0,t.ajax)("/clear",{type:"POST"}).then((function(){e.model.reload()}))},removeMessage:function(e){var t=this.model.currentRow.group?this.model.currentRow:null,n=this.model.rows,r=t?n.indexOf(t):n.indexOf(e)
 e.destroy(),e.set("selected",!1),this.model.set("total",this.model.total-1)
 var a=!1,o=0
-t?(o=t.messages.indexOf(e),t.messages.removeObject(e),o=Math.min(o,t.messages.length-1),0===t.messages.length&&(n.removeObject(t),a=!0)):(n.removeObject(e),a=!0),a?r>0?this.model.selectRow(n[r-1]):this.model.total>0?this.model.selectRow(n[0]):this.model.reload():t&&this.model.selectRow(n[r],{messageIndex:o})},solveMessage:function(e){this.model.solve(e)},groupedMessageChangedAction:function(e){this.model.groupedMessageChanged(e)},envChangedAction:function(e){this.model.envChanged(e)},updateFilter:function(e){var t=this
-this.toggleProperty(e),this.model.set(e,this[e]),this.model.reload().then((function(){return t.model.updateSelectedRow()}))},updateSearch:function(e){e!==this.search&&(e&&1===e.length||Ember.run.debounce(this,this.doSearch,e,250))}},doSearch:function(e){var t=this
+t?(o=t.messages.indexOf(e),t.messages.removeObject(e),o=Math.min(o,t.messages.length-1),0===t.messages.length&&(n.removeObject(t),a=!0)):(n.removeObject(e),a=!0),a?r>0?this.model.selectRow(n[r-1]):this.model.total>0?this.model.selectRow(n[0]):this.model.reload():t&&this.model.selectRow(n[r],{messageIndex:o})},solveMessage:function(e){this.model.solve(e)},groupedMessageChangedAction:function(e){this.model.groupedMessageChanged(e)},envChangedAction:function(e){this.model.envChanged(e)},updateFilter:function(e){var n=this
+this.toggleProperty(e),this.model.set(e,this[e]),(0,t.setLocalStorage)(e,this[e]),this.model.reload().then((function(){return n.model.updateSelectedRow()}))},updateSearch:function(e){e!==this.search&&(e&&1===e.length||Ember.run.debounce(this,this.doSearch,e,250))}},doSearch:function(e){var t=this
 this.model.set("search",e),this.model.reload().then((function(){return t.model.updateSelectedRow()}))}})
 e.default=r})),define("client-app/controllers/show",["exports"],(function(e){Object.defineProperty(e,"__esModule",{value:!0}),e.default=void 0
 var t=Ember.Controller.extend({envPosition:0,actions:{protect:function(){this.get("model").protect()},unprotect:function(){this.get("model").unprotect()},envChanged:function(e){this.set("envPosition",e)}}})
@@ -165,7 +165,9 @@ i.push('<tr title="'.concat(f,'"><td>').concat(e,"</td><td>").concat(m,"</td></t
 i.push("<tr><td></td><td><table>"),i.push("<td>".concat(s(t),"</td><td>").concat(e(n,!0),"</td>")),i.push("</table></td></tr>")}))
 var p=a?"":"env-table"
 return"<table class='".concat(p,"'>").concat(i.join("\n"),"</table>")},e.clone=function(e){var t={}
-return Object.keys(e).forEach((function(n){t[n]=e[n]})),t}
+return Object.keys(e).forEach((function(n){t[n]=e[n]})),t},e.setLocalStorage=function(e,t){try{window.localStorage&&(e="logster-"+e,window.localStorage.setItem(e,t))}catch(n){}},e.getLocalStorage=function(e,t){try{if(window.localStorage){e="logster-"+e
+var n=window.localStorage.getItem(e)
+return null===n?t:"true"===n||"false"!==n&&n}return t}catch(r){return t}}
 var r,a,o,i={"&":"&amp;","<":"&lt;",">":"&gt;",'"':"&quot;","'":"&#39;","/":"&#x2F;"}
 function s(e){return String(e).replace(/[&<>"'/]/g,(function(e){return i[e]}))}function l(e,n){return new Ember.RSVP.Promise((function(r,a){n=n||{}
 var o=new XMLHttpRequest
@@ -292,4 +294,4 @@ var t=Ember.HTMLBars.template({id:"QRu+EVou",block:'{"symbols":[],"statements":[
 e.default=t})),define("client-app/templates/show",["exports"],(function(e){Object.defineProperty(e,"__esModule",{value:!0}),e.default=void 0
 var t=Ember.HTMLBars.template({id:"Xt+M1cRV",block:'{"symbols":[],"statements":[[4,"link-to",null,[["route"],["index"]],{"statements":[[0,"Recent"]],"parameters":[]},null],[0,"\\n"],[7,"div",true],[10,"id","bottom-panel"],[10,"class","full"],[8],[0,"\\n  "],[1,[28,"message-info",null,[["currentMessage","showTitle","envChangedAction","currentEnvPosition","actionsInMenu"],[[24,["model"]],"true",[28,"action",[[23,0,[]],"envChanged"],null],[24,["envPosition"]],false]]],false],[0,"\\n"],[9],[0,"\\n"]],"hasEval":false}',meta:{moduleName:"client-app/templates/show.hbs"}})
 e.default=t})),define("client-app/config/environment",[],(function(){try{var e="client-app/config/environment",t=document.querySelector('meta[name="'+e+'"]').getAttribute("content"),n={default:JSON.parse(decodeURIComponent(t))}
-return Object.defineProperty(n,"__esModule",{value:!0}),n}catch(r){throw new Error('Could not read config from meta tag with name "'+e+'".')}})),runningTests||require("client-app/app").default.create({name:"client-app",version:"0.0.0+d01416df"})
+return Object.defineProperty(n,"__esModule",{value:!0}),n}catch(r){throw new Error('Could not read config from meta tag with name "'+e+'".')}})),runningTests||require("client-app/app").default.create({name:"client-app",version:"0.0.0+9146d033"})

--- a/client-app/app/controllers/index.js
+++ b/client-app/app/controllers/index.js
@@ -1,15 +1,19 @@
 import Controller from "@ember/controller";
-import { ajax } from "client-app/lib/utilities";
+import {
+  ajax,
+  getLocalStorage,
+  setLocalStorage
+} from "client-app/lib/utilities";
 import { computed } from "@ember/object";
 import Preload from "client-app/lib/preload";
 import { debounce } from "@ember/runloop";
 
 export default Controller.extend({
-  showDebug: false,
-  showInfo: false,
-  showWarn: false,
-  showErr: true,
-  showFatal: true,
+  showDebug: getLocalStorage("showDebug", false),
+  showInfo: getLocalStorage("showInfo", false),
+  showWarn: getLocalStorage("showWarn", false),
+  showErr: getLocalStorage("showErr", true),
+  showFatal: getLocalStorage("showFatal", true),
   search: "",
   queryParams: ["search"],
 
@@ -109,6 +113,7 @@ export default Controller.extend({
     updateFilter(name) {
       this.toggleProperty(name);
       this.model.set(name, this[name]);
+      setLocalStorage(name, this[name]);
       this.model.reload().then(() => this.model.updateSelectedRow());
     },
 

--- a/client-app/app/controllers/index.js
+++ b/client-app/app/controllers/index.js
@@ -5,9 +5,9 @@ import Preload from "client-app/lib/preload";
 import { debounce } from "@ember/runloop";
 
 export default Controller.extend({
-  showDebug: true,
-  showInfo: true,
-  showWarn: true,
+  showDebug: false,
+  showInfo: false,
+  showWarn: false,
   showErr: true,
   showFatal: true,
   search: "",
@@ -108,14 +108,7 @@ export default Controller.extend({
 
     updateFilter(name) {
       this.toggleProperty(name);
-      const filter = [];
-      ["Debug", "Info", "Warn", "Err", "Fatal"].forEach((severity, index) => {
-        if (this.get(`show${severity}`)) {
-          filter.push(index);
-        }
-      });
-      filter.push(5); // always show unknown, rare
-      this.model.set("filter", filter);
+      this.model.set(name, this[name]);
       this.model.reload().then(() => this.model.updateSelectedRow());
     },
 

--- a/client-app/app/lib/utilities.js
+++ b/client-app/app/lib/utilities.js
@@ -193,3 +193,37 @@ export function clone(object) {
   });
   return copy;
 }
+
+export function setLocalStorage(key, value) {
+  try {
+    if (window.localStorage) {
+      key = "logster-" + key;
+      window.localStorage.setItem(key, value);
+    }
+  } catch {}
+}
+
+export function getLocalStorage(key, fallback) {
+  try {
+    if (window.localStorage) {
+      key = "logster-" + key;
+      const value = window.localStorage.getItem(key);
+      if (value === null) {
+        // key doesn't exist
+        return fallback;
+      }
+      if (value === "true") {
+        return true;
+      }
+      if (value === "false") {
+        return false;
+      }
+      // Add more cases here for numbers, null, undefined etc. as/when needed
+      return value;
+    } else {
+      return fallback;
+    }
+  } catch {
+    return fallback;
+  }
+}

--- a/client-app/app/models/message-collection.js
+++ b/client-app/app/models/message-collection.js
@@ -6,7 +6,8 @@ import { default as EmberObject, computed } from "@ember/object";
 import { A } from "@ember/array";
 
 const BATCH_SIZE = 50;
-const DEFAULT_FILTER = [0, 1, 2, 3, 4, 5];
+
+export const SEVERITIES = ["Debug", "Info", "Warn", "Err", "Fatal"];
 
 export default EmberObject.extend({
   total: 0,
@@ -16,10 +17,20 @@ export default EmberObject.extend({
   currentEnvPosition: 0,
   currentGroupedMessagesPosition: 0,
 
+  filter: computed(...SEVERITIES.map(s => `show${s}`), function() {
+    const filter = [];
+    SEVERITIES.forEach((severity, index) => {
+      if (this[`show${severity}`]) {
+        filter.push(index);
+      }
+    });
+    filter.push(5); // always show unknown, rare
+    return filter;
+  }),
+
   init() {
     this._super(...arguments);
     this.setProperties({
-      filter: DEFAULT_FILTER,
       search: "",
       rows: A()
     });

--- a/client-app/app/routes/index.js
+++ b/client-app/app/routes/index.js
@@ -1,5 +1,8 @@
 import Route from "@ember/routing/route";
-import MessageCollection from "client-app/models/message-collection";
+import {
+  default as MessageCollection,
+  SEVERITIES
+} from "client-app/models/message-collection";
 import { isHidden } from "client-app/lib/utilities";
 
 export default Route.extend({
@@ -10,6 +13,9 @@ export default Route.extend({
 
   setupController(controller, model) {
     this._super(controller, model);
+    SEVERITIES.forEach(severity =>
+      model.set(`show${severity}`, controller[`show${severity}`])
+    );
     model.reload();
 
     let times = 0;

--- a/client-app/package-lock.json
+++ b/client-app/package-lock.json
@@ -16270,7 +16270,7 @@
     },
     "http-errors": {
       "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+      "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "dev": true,
       "requires": {

--- a/test/logster/middleware/test_reporter.rb
+++ b/test/logster/middleware/test_reporter.rb
@@ -28,19 +28,19 @@ class TestReporter < Minitest::Test
 
     reporter = Logster::Middleware::Reporter.new(nil)
     env = Rack::MockRequest.env_for("/logs/report_js_error?message=hello")
-    status, = reporter.call(env)
+    reporter.call(env)
 
     assert_equal(Logger::Severity::WARN, Logster.store.latest[-1].severity)
 
     reporter = Logster::Middleware::Reporter.new(nil)
     env = Rack::MockRequest.env_for("/logs/report_js_error?message=hello&severity=invalid")
-    status, = reporter.call(env)
+    reporter.call(env)
 
     assert_equal(Logger::Severity::WARN, Logster.store.latest[-1].severity)
 
     reporter = Logster::Middleware::Reporter.new(nil)
     env = Rack::MockRequest.env_for("/logs/report_js_error?message=hello&severity=error")
-    status, = reporter.call(env)
+    reporter.call(env)
 
     assert_equal(Logger::Severity::ERROR, Logster.store.latest[-1].severity)
   end

--- a/website/Gemfile.lock
+++ b/website/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    logster (2.9.2)
+    logster (2.9.3)
 
 GEM
   remote: https://rubygems.org/


### PR DESCRIPTION
This PR makes the severity checkboxes like this when you open Logster:

![image](https://user-images.githubusercontent.com/17474474/91776274-bf774100-ebf5-11ea-9f68-faea51a50201.png)


This is a change Joffrey asked for, and I think it makes sense, at least for us at Discourse. I almost always turn off everything below 'Error' whenever I open our logs, so it would be nice if Logster did this for me.

Are you OK with this change @SamSaffron? Should the default severity levels that are on by default be configurable?