### PR TITLE
FIX: Stop encoding errors when converting Message objects to JSON

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
             ${{ runner.os }}-${{ matrix.ruby }}-gems-
       - name: Setup gems
         run: |
+          gem install bundler
           bundle config path vendor/bundle
           bundle install --jobs 4
       - name: Rubocop

--- a/lib/logster/message.rb
+++ b/lib/logster/message.rb
@@ -99,7 +99,7 @@ module Logster
           env["time"] = @timestamp || get_timestamp
         end
       end
-      @env = Message.populate_from_env(env)
+      self.env = Message.populate_from_env(env)
     end
 
     def self.default_env

--- a/test/logster/test_base_store.rb
+++ b/test/logster/test_base_store.rb
@@ -188,4 +188,16 @@ class TestBaseStore < Minitest::Test
       refute_includes(store.reported.first.env.keys.map(&:to_sym), :backtrace)
     end
   end
+
+  def test_envs_with_invalid_encoding_dont_raise_errors
+    msg = @store.report(
+      Logger::WARN,
+      '',
+      'me have invalid encoding',
+      env: {
+        axe: "a\xF1xasa"
+      }
+    )
+    assert_equal("a�xasa", msg.env[:axe])
+  end
 end


### PR DESCRIPTION
`env` may contain invalid strings that cause errors when converting Messages objects to JSON. This PR fixes the problem by `scrub`ing all invalid strings inside `env`.