### PR TITLE
FEATURE: Optionally use full hostname

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+- 2021-07-01: 2.9.7
+
+  - FEATURE: Optionally use full hostname
+
 - 2021-02-19: 2.9.6
 
   - UX: Make `Warn` level visible by default

--- a/lib/logster/configuration.rb
+++ b/lib/logster/configuration.rb
@@ -18,7 +18,8 @@ module Logster
       :gems_dir,
       :max_env_bytes,
       :max_env_count_per_message,
-      :maximum_message_length
+      :maximum_message_length,
+      :use_full_hostname
     )
 
     attr_writer :subdirectory
@@ -39,6 +40,7 @@ module Logster
       @enable_backtrace_links = true
       @gems_dir = Gem.dir + "/gems/"
       @maximum_message_length = 2000
+      @use_full_hostname = nil
 
       @allow_grouping = false
 

--- a/lib/logster/message.rb
+++ b/lib/logster/message.rb
@@ -80,7 +80,8 @@ module Logster
     end
 
     def self.hostname
-      @hostname ||= `hostname`.strip! rescue "<unknown>"
+      command = Logster.config.use_full_hostname ? `hostname -f` : `hostname`
+      @hostname ||= command.strip! rescue "<unknown>"
     end
 
     def populate_from_env(env)

--- a/lib/logster/version.rb
+++ b/lib/logster/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Logster
-  VERSION = "2.9.6"
+  VERSION = "2.9.7"
 end

--- a/test/logster/test_message.rb
+++ b/test/logster/test_message.rb
@@ -79,6 +79,7 @@ class TestMessage < MiniTest::Test
   end
 
   def test_use_full_hostname
+    Logster::Message.instance_variable_set(:@hostname, nil)
     Logster.config.use_full_hostname = true
     msg = Logster::Message.new(0, '', 'test', 10)
     msg.populate_from_env({})

--- a/test/logster/test_message.rb
+++ b/test/logster/test_message.rb
@@ -87,6 +87,7 @@ class TestMessage < MiniTest::Test
     assert_equal(`hostname -f`.strip!, msg.env["hostname"])
   ensure
     Logster.config.use_full_hostname = nil
+    Logster::Message.instance_variable_set(:@hostname, nil)
   end
 
   def test_merging_sums_count_for_both_messages

--- a/test/logster/test_message.rb
+++ b/test/logster/test_message.rb
@@ -78,6 +78,16 @@ class TestMessage < MiniTest::Test
     Logster.config.application_version = nil
   end
 
+  def test_use_full_hostname
+    Logster.config.use_full_hostname = true
+    msg = Logster::Message.new(0, '', 'test', 10)
+    msg.populate_from_env({})
+
+    assert_equal(`hostname -f`.strip!, msg.env["hostname"])
+  ensure
+    Logster.config.use_full_hostname = nil
+  end
+
   def test_merging_sums_count_for_both_messages
     msg1 = Logster::Message.new(0, '', 'test', 10, count: 15)
     msg2 = Logster::Message.new(0, '', 'test', 20, count: 13)


### PR DESCRIPTION
Adds a new configuration option, off by default.

Setting `Logster.config.use_full_hostname = true` will switch to using full hostnames in the reports.

The added test is not super useful because in a test environment `hostname -f` will be the same as `hostname`, but it ensures this doesn't fail. 