### PR TITLE
FIX: We weren't properly memoizing the hostname

### DIFF
--- a/lib/logster/message.rb
+++ b/lib/logster/message.rb
@@ -80,8 +80,10 @@ module Logster
     end
 
     def self.hostname
-      command = Logster.config.use_full_hostname ? `hostname -f` : `hostname`
-      @hostname ||= command.strip! rescue "<unknown>"
+      @hostname ||= begin
+        command = (Logster.config.use_full_hostname ? `hostname -f` : `hostname`) rescue "<unknown>"
+        command.strip!
+      end
     end
 
     def populate_from_env(env)

--- a/lib/logster/version.rb
+++ b/lib/logster/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Logster
-  VERSION = "2.9.7"
+  VERSION = "2.9.8"
 end


### PR DESCRIPTION
This could have a huge performance cost when logging, as it would shell
out to get the hostname very often.