### PR TITLE
FEATURE: Improve support for logging error objects

### DIFF
--- a/lib/logster/logger.rb
+++ b/lib/logster/logger.rb
@@ -74,9 +74,13 @@ module Logster
       # own methods don't show up as the first few frames in the backtrace
       if !opts || !opts.key?(:backtrace)
         opts ||= {}
-        backtrace = caller_locations
-        while backtrace.first.path.end_with?("/logger.rb")
-          backtrace.shift
+        backtrace = message.backtrace if message.class <= ::Exception
+        backtrace ||= progname.backtrace if progname.class <= ::Exception
+        if !backtrace
+          backtrace = caller_locations
+          while backtrace.first.path.end_with?("/logger.rb")
+            backtrace.shift
+          end
         end
         backtrace = backtrace.join("\n")
         opts[:backtrace] = backtrace

--- a/test/logster/test_logger.rb
+++ b/test/logster/test_logger.rb
@@ -106,4 +106,26 @@ class TestLogger < Minitest::Test
     @logger.skip_store = true
     @logger.warn("testing")
   end
+
+  def test_logging_an_error_gets_backtrace_from_the_error
+    exception = error_instance(Exception)
+    std_err = error_instance(StandardError)
+    custom_err = error_instance(Class.new(StandardError))
+
+    @logger.error(exception)
+    @logger.fatal(std_err)
+    @logger.fatal(custom_err)
+
+    assert_equal exception.backtrace.join("\n"), @store.calls[0][3][:backtrace]
+    assert_equal std_err.backtrace.join("\n"), @store.calls[1][3][:backtrace]
+    assert_equal custom_err.backtrace.join("\n"), @store.calls[2][3][:backtrace]
+  end
+
+  private
+
+  def error_instance(error_class)
+    raise error_class.new
+  rescue error_class => e
+    e
+  end
 end


### PR DESCRIPTION
Currently, if you rescue an exception and log the exception object to Logster, the backtrace points to the location where the error is logged rather the original location that raised the exception. This PR improves adds special handling for when an exception object is passed to Logster so that the backtrace of the exception object is used rather than the caller location.