### PR TITLE
FIX: Use search query param as filter

### DIFF
--- a/client-app/app/controllers/index.js
+++ b/client-app/app/controllers/index.js
@@ -1,12 +1,8 @@
-import Controller from "@ember/controller";
-import {
-  ajax,
-  getLocalStorage,
-  setLocalStorage
-} from "client-app/lib/utilities";
-import { computed } from "@ember/object";
-import Preload from "client-app/lib/preload";
 import { debounce } from "@ember/runloop";
+import { computed } from "@ember/object";
+import Controller from "@ember/controller";
+import { ajax, getLocalStorage, setLocalStorage } from "client-app/lib/utilities";
+import Preload from "client-app/lib/preload";
 
 export default Controller.extend({
   showDebug: getLocalStorage("showDebug", false),
@@ -14,7 +10,7 @@ export default Controller.extend({
   showWarn: getLocalStorage("showWarn", true),
   showErr: getLocalStorage("showErr", true),
   showFatal: getLocalStorage("showFatal", true),
-  search: "",
+  search: null,
   queryParams: ["search"],
 
   showSettings: computed(function() {
@@ -129,6 +125,14 @@ export default Controller.extend({
       debounce(this, this.doSearch, term, 250);
     }
   },
+
+  searchTerm: computed("search", function () {
+    if (this.search) {
+      this.doSearch(this.search)
+      return this.search;
+    }
+    return null;
+  }),
 
   doSearch(term) {
     this.model.set("search", term);

--- a/client-app/app/templates/index.hbs
+++ b/client-app/app/templates/index.hbs
@@ -87,6 +87,7 @@
         type="text"
         class="search"
         placeholder="Search"
+        value={{searchTerm}}
         onkeyup={{action "updateSearch" value="target.value"}}
       />
       <div class="footer-btns">

--- a/client-app/package.json
+++ b/client-app/package.json
@@ -43,6 +43,7 @@
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-qunit": "^4.6.0",
     "ember-resolver": "^7.0.0",
+    "ember-sinon-qunit": "^6.0.0",
     "ember-source": "^3.15.0",
     "eslint-plugin-ember": "^7.13.0",
     "eslint-plugin-node": "^10.0.0",

--- a/client-app/tests/unit/controllers/index-test.js
+++ b/client-app/tests/unit/controllers/index-test.js
@@ -7,12 +7,6 @@ import * as utilities from "client-app/lib/utilities";
 module('Unit | Controller | index', function (hooks) {
   setupTest(hooks);
 
-  // Replace this with your real tests.
-  test('it exists', function (assert) {
-    let controller = this.owner.lookup('controller:index');
-    assert.ok(controller);
-  });
-
   test('uses search param to filter results', function (assert) {
     const controller = this.owner.lookup('controller:index');
     const ajaxStub = sinon.stub(utilities, 'ajax')

--- a/client-app/tests/unit/controllers/index-test.js
+++ b/client-app/tests/unit/controllers/index-test.js
@@ -1,12 +1,36 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
+import { default as MessageCollection } from "client-app/models/message-collection";
+import sinon from "sinon";
+import * as utilities from "client-app/lib/utilities";
 
-module('Unit | Controller | index', function(hooks) {
+module('Unit | Controller | index', function (hooks) {
   setupTest(hooks);
 
   // Replace this with your real tests.
-  test('it exists', function(assert) {
+  test('it exists', function (assert) {
     let controller = this.owner.lookup('controller:index');
     assert.ok(controller);
+  });
+
+  test('uses search param to filter results', function (assert) {
+    const controller = this.owner.lookup('controller:index');
+    const ajaxStub = sinon.stub(utilities, 'ajax')
+    const messages = MessageCollection.create();
+    const row1 = {"message": "error tomtom", "severity": 2, "key": "ce1f53b0cc"};
+    const row2 = {"message": "error steaky", "severity": 3, "key": "b083352825"};
+
+    messages.rows.addObjects([row1, row2]);
+    controller.set("model", messages)
+
+    assert.equal(controller.searchTerm, null, 'initial value is null');
+    assert.deepEqual(controller.model.rows, [row1, row2], 'all rows');
+
+    ajaxStub.callsFake(() => Promise.resolve({search: "tomtom", filter: [5], messages: []}));
+    controller.set("search", "tomtom");
+
+    assert.equal(controller.searchTerm, "tomtom", 'search sets search term');
+    assert.equal(ajaxStub.firstCall.args[0], "/messages.json", "get messages");
+    assert.deepEqual(ajaxStub.firstCall.args[1], {"data": {"filter": "5", "search": "tomtom"}}, "with correct terms");
   });
 });


### PR DESCRIPTION
Allows us to search by queryParam `http://<site>/logs?search=no+forum`

The queryParam existed before but probably regressed.

https://github.com/discourse/logster/blob/ac969c74f4fdcb9935364e82f4132a8ad19c75a6/client-app/app/controllers/index.js#L17-L18

<img width="368" alt="Screenshot 2022-03-17 at 1 14 50 AM" src="https://user-images.githubusercontent.com/1555215/158648832-b9a5f222-6b93-4659-966f-274516b9884f.png">

