### PR TITLE
Fix Redis pipelining deprecation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-- Unreleased
+- 2022-04-21: 2.11.1
 
   - FIX: Redis pipelining deprecation (#159)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+- Unreleased
+
+  - FIX: Redis pipelining deprecation (#159)
+
 - 2022-03-12: 2.11.0
 
   - FEATURE: Improve support for logging error objects (#153)

--- a/lib/logster/version.rb
+++ b/lib/logster/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Logster
-  VERSION = "2.11.0"
+  VERSION = "2.11.1"
 end


### PR DESCRIPTION
Deprecation message: `Pipelining commands on a Redis instance is
deprecated and will be removed in Redis 5.0.0`