### PR TITLE
FIX: store override level in thread local storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # CHANGELOG
+- 2022-04-28: 2.11.2
+
+  - FIX: store override level in thread local storage (Truffle Ruby compatability)
 
 - 2022-04-21: 2.11.1
 

--- a/lib/logster/logger.rb
+++ b/lib/logster/logger.rb
@@ -14,10 +14,15 @@ module Logster
       @store = store
       @chained = []
       @skip_store = false
+      @logster_override_level_key = "logster_override_level_#{object_id}"
     end
 
     def override_level=(val)
-      Thread.current[:logster_override_level] = val
+      Thread.current[@logster_override_level_key] = val
+    end
+
+    def override_level
+      Thread.current[@logster_override_level_key]
     end
 
     def chain(logger)
@@ -46,7 +51,7 @@ module Logster
     end
 
     def level
-      Thread.current[:logster_override_level] || @level
+      Thread.current[@logster_override_level_key] || @level
     end
 
     def add_with_opts(severity, message = nil, progname = progname(), opts = nil, &block)

--- a/lib/logster/logger.rb
+++ b/lib/logster/logger.rb
@@ -4,7 +4,7 @@ require 'logger'
 
 module Logster
   class Logger < ::Logger
-    LOGSTER_ENV = "logster_env".freeze
+    LOGSTER_ENV = "logster_env"
 
     attr_accessor :store, :skip_store
     attr_reader :chained
@@ -12,21 +12,12 @@ module Logster
     def initialize(store)
       super(nil)
       @store = store
-      @override_levels = nil
       @chained = []
       @skip_store = false
     end
 
     def override_level=(val)
-      tid = Thread.current.object_id
-
-      ol = @override_levels
-      if val.nil? && ol && ol.key?(tid)
-        ol.delete(tid)
-        @override_levels = nil if ol.length == 0
-      elsif val
-        (@override_levels ||= {})[tid] = val
-      end
+      Thread.current[:logster_override_level] = val
     end
 
     def chain(logger)
@@ -55,8 +46,7 @@ module Logster
     end
 
     def level
-      ol = @override_levels
-      (ol && ol[Thread.current.object_id]) || @level
+      Thread.current[:logster_override_level] || @level
     end
 
     def add_with_opts(severity, message = nil, progname = progname(), opts = nil, &block)

--- a/lib/logster/version.rb
+++ b/lib/logster/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Logster
-  VERSION = "2.11.1"
+  VERSION = "2.11.2"
 end

--- a/test/logster/test_logger.rb
+++ b/test/logster/test_logger.rb
@@ -26,6 +26,12 @@ class TestLogger < Minitest::Test
   end
 
   def test_per_thread_override
+    logger2 = Logster::Logger.new(@store)
+    logger2.override_level = 2
+
+    # we should not leak between objects
+    assert_nil @logger.override_level
+
     @logger.override_level = 2
 
     @logger.add(0, "test", "prog", backtrace: "backtrace", env: { a: "x" })


### PR DESCRIPTION
Removes complex non thread safe code and replaces with a far simpler
pattern.

This corrects a concurrency issue detected by the Truffle Ruby team
