### PR TITLE
DEV: Avoid deprecation warning in Redis 4.8

### DIFF
--- a/lib/logster/redis_store.rb
+++ b/lib/logster/redis_store.rb
@@ -318,11 +318,11 @@ module Logster
     end
 
     def insert_pattern(set_name, pattern)
-      @redis.sadd(set_name, pattern)
+      @redis.sadd(set_name, [pattern])
     end
 
     def remove_pattern(set_name, pattern)
-      @redis.srem(set_name, pattern)
+      @redis.srem(set_name, [pattern])
     end
 
     def get_patterns(set_name)
@@ -434,9 +434,9 @@ module Logster
       redis.hset(hash_key, message.key, message.to_json(exclude_env: true))
       push_env(message.key, message.env, redis: redis) if save_env
       if message.protected
-        redis.sadd(protected_key, message.key)
+        redis.sadd(protected_key, [message.key])
       else
-        redis.srem(protected_key, message.key)
+        redis.srem(protected_key, [message.key])
       end
     end
 


### PR DESCRIPTION
In Redis 4.8

```
Deprecate sadd and srem returning a boolean when called with a single argument. To enable the redis 5.0 behavior you can set Redis.sadd_returns_boolean = true.
```

However, we want Logster to remain backwards compatible with older Redis
version so we pass in an array instead of using `sadd?` or `srem?`.