### PR TITLE
FIX: Don't throw on non-gem backtrace lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # CHANGELOG
 
-- 2023-03-03: 2.12.0
+- 2023-03-03: 2.12.2
+
+  - FIX: Don't throw on non-gem backtrace lines
+
+- 2023-03-03: 2.12.1
+  Note: 2.12.0 was yanked due to a release process error
 
   - DEV: Upgrade to Ember 3.28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # CHANGELOG
 
-- 2023-03-03: 2.12.2
+- 2023-03-10: 2.12.2
 
   - FIX: Don't throw on non-gem backtrace lines
 
-- 2023-03-03: 2.12.1
+- 2023-03-10: 2.12.1
   Note: 2.12.0 was yanked due to a release process error
 
   - DEV: Upgrade to Ember 3.28

--- a/client-app/app/components/back-trace.js
+++ b/client-app/app/components/back-trace.js
@@ -76,6 +76,10 @@ export default class BackTrace extends Component {
 
     const regexResults = line.match(/([^/]+)\/(.+\/)(.+):(\d+):.*/);
     const [, gemWithVersion, path, filename, lineNumber] = regexResults || [];
+    if (!gemWithVersion) {
+      return null;
+    }
+
     const gemsData = Preloaded.get("gems_data");
     const match = gemsData
       .filter((g) => gemWithVersion.startsWith(`${g.name}-`))

--- a/client-app/tests/integration/components/back-trace-test.js
+++ b/client-app/tests/integration/components/back-trace-test.js
@@ -66,6 +66,23 @@ string@https://discourse-cdn.com/assets/application-f59d2.br.js:1:27869`
     });
   });
 
+  test("non-gem backtraces don't break things", async function (assert) {
+    this.set(
+      "backtrace",
+      `/ruby/gems/activesupport-7.0.4.1/lib/active_support/deprecation/behaviors.rb:33:in \`block in <class:Deprecation>'
+/ruby/gems/activesupport-7.0.4.1/lib/active_support/deprecation/reporting.rb:26:in \`block (2 levels) in warn'
+/ruby/gems/activesupport-7.0.4.1/lib/active_support/deprecation/reporting.rb:26:in \`each'
+/ruby/gems/activesupport-7.0.4.1/lib/active_support/deprecation/reporting.rb:26:in \`block in warn'
+<internal:kernel>:90:in \`tap'
+/ruby/gems/activesupport-7.0.4.1/lib/active_support/deprecation/reporting.rb:22:in \`warn'`
+    );
+    await render(hbs`<BackTrace @backtrace={{this.backtrace}} />`);
+    const lines = this.backtrace.split("\n");
+    findAll("div.backtrace-line").forEach((node, index) => {
+      assert.strictEqual(node.textContent.trim(), lines[index]);
+    });
+  });
+
   test("Github links use commit sha", async function (assert) {
     const backtrace = `/var/www/discourse/lib/permalink_constraint.rb:6:in \`matches?'`;
     let env = [

--- a/lib/logster/version.rb
+++ b/lib/logster/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Logster
-  VERSION = "2.12.1"
+  VERSION = "2.12.2"
 end


### PR DESCRIPTION
Lines like `(eval):5:in '_fast_attributes'` or `<internal:kernel>:90:in 'tap'`