### PR TITLE
DEV: Format files with syntax_tree gem

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,11 @@ jobs:
         working-directory: client-app
         run: yarn install
 
+      - name: Syntax Tree
+        if: ${{ !cancelled() }}
+        run: |
+            bundle exec stree check Gemfile $(git ls-files '*.rb') $(git ls-files '*.rake') $(git ls-files '*.thor')
+
       - name: JS linting
         if: ${{ !cancelled() }}
         working-directory: client-app

--- a/.streerc
+++ b/.streerc
@@ -1,0 +1,2 @@
+--print-width=100
+--plugins=plugin/trailing_comma

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
 # Specify your gem's dependencies in rack-log-viewer.gemspec
 gemspec

--- a/client-app/preload-json-manager.rb
+++ b/client-app/preload-json-manager.rb
@@ -3,13 +3,13 @@
 # This script takes care of updating the content of the preloaded json in tests/index.html
 # All you need to do is update the `tests_index_html` hash and run the script
 
-require 'bundler/inline'
-require 'json'
-require 'cgi'
+require "bundler/inline"
+require "json"
+require "cgi"
 
 gemfile do
-  source 'https://rubygems.org'
-  gem 'nokogiri'
+  source "https://rubygems.org"
+  gem "nokogiri"
 end
 
 tests_index_html = {
@@ -17,23 +17,16 @@ tests_index_html = {
   gems_dir: "/var/www/discourse/vendor/bundle/ruby/2.6.0/gems/",
   backtrace_links_enabled: true,
   gems_data: [
-    {
-      name: "activerecord",
-      url: "https://github.com/rails/rails/tree/v6.0.1/activerecord"
-    }
+    { name: "activerecord", url: "https://github.com/rails/rails/tree/v6.0.1/activerecord" },
   ],
   directories: [
-    {
-      path: "/var/www/discourse",
-      url: "https://github.com/discourse/discourse",
-      main_app: true
-    },
+    { path: "/var/www/discourse", url: "https://github.com/discourse/discourse", main_app: true },
     {
       path: "/var/www/discourse/plugins/discourse-prometheus",
-      url: "https://github.com/discourse/discourse-prometheus"
-    }
+      url: "https://github.com/discourse/discourse-prometheus",
+    },
   ],
-  application_version: "ce512452b512b909c38e9c63f2a0e1f8c17a2399"
+  application_version: "ce512452b512b909c38e9c63f2a0e1f8c17a2399",
 }
 
 content = File.read("tests/index.html")

--- a/lib/examples/sidekiq_logster_reporter.rb
+++ b/lib/examples/sidekiq_logster_reporter.rb
@@ -4,19 +4,17 @@ class SidekiqLogsterReporter
   def call(ex, context = {})
     # Pass context to Logster
     fake_env = {}
-    context.each do |key, value|
-      Logster.add_to_env(fake_env, key, value)
-    end
+    context.each { |key, value| Logster.add_to_env(fake_env, key, value) }
 
     text = "Job exception: #{ex}\n"
-    if ex.backtrace
-      Logster.add_to_env(fake_env, :backtrace, ex.backtrace)
-    end
+    Logster.add_to_env(fake_env, :backtrace, ex.backtrace) if ex.backtrace
 
     Thread.current[Logster::Logger::LOGSTER_ENV] = fake_env
     Logster.logger.error(text)
   rescue => e
-    Logster.logger.fatal("Failed to log exception #{ex} #{hash}\nReason: #{e.class} #{e}\n#{e.backtrace.join("\n")}")
+    Logster.logger.fatal(
+      "Failed to log exception #{ex} #{hash}\nReason: #{e.class} #{e}\n#{e.backtrace.join("\n")}",
+    )
   ensure
     Thread.current[Logster::Logger::LOGSTER_ENV] = nil
   end

--- a/lib/logster.rb
+++ b/lib/logster.rb
@@ -1,19 +1,19 @@
 # frozen_string_literal: true
 
-require 'logster/version'
-require 'logster/logger'
-require 'logster/message'
-require 'logster/configuration'
-require 'logster/web'
-require 'logster/ignore_pattern'
-require 'logster/pattern'
-require 'logster/suppression_pattern'
-require 'logster/grouping_pattern'
-require 'logster/group'
-require 'logster/cache'
+require "logster/version"
+require "logster/logger"
+require "logster/message"
+require "logster/configuration"
+require "logster/web"
+require "logster/ignore_pattern"
+require "logster/pattern"
+require "logster/suppression_pattern"
+require "logster/grouping_pattern"
+require "logster/group"
+require "logster/cache"
 
-if defined? Redis
-  require 'logster/redis_store'
+if defined?(Redis)
+  require "logster/redis_store"
 else
   STDERR.puts "ERROR: Redis is not loaded, ensure redis gem is required before logster"
   exit
@@ -57,6 +57,4 @@ end
 # check logster/configuration.rb for config options
 # Logster.config.environments << :staging
 
-if defined?(::Rails) && ::Rails::VERSION::MAJOR.to_i >= 3
-  require 'logster/rails/railtie'
-end
+require "logster/rails/railtie" if defined?(::Rails) && ::Rails::VERSION::MAJOR.to_i >= 3

--- a/lib/logster/cache.rb
+++ b/lib/logster/cache.rb
@@ -8,7 +8,8 @@ module Logster
     end
 
     def fetch(key)
-      if !@hash.key?(key) || @hash[key][:created_at] + @age < Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      if !@hash.key?(key) ||
+           @hash[key][:created_at] + @age < Process.clock_gettime(Process::CLOCK_MONOTONIC)
         @hash[key] = { data: yield, created_at: Process.clock_gettime(Process::CLOCK_MONOTONIC) }
       end
       @hash[key][:data]

--- a/lib/logster/configuration.rb
+++ b/lib/logster/configuration.rb
@@ -19,7 +19,7 @@ module Logster
       :max_env_bytes,
       :max_env_count_per_message,
       :maximum_message_length,
-      :use_full_hostname
+      :use_full_hostname,
     )
 
     attr_writer :subdirectory
@@ -27,7 +27,7 @@ module Logster
     def initialize
       # lambda |env,block|
       @current_context = lambda { |_, &block| block.call }
-      @environments = [:development, :production]
+      @environments = %i[development production]
       @subdirectory = nil
       @env_expandable_keys = []
       @enable_custom_patterns_via_ui = false
@@ -50,7 +50,7 @@ module Logster
     end
 
     def subdirectory
-      @subdirectory || '/logs'
+      @subdirectory || "/logs"
     end
   end
 end

--- a/lib/logster/defer_logger.rb
+++ b/lib/logster/defer_logger.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'logster/scheduler'
+require "logster/scheduler"
 
 module Logster
   class DeferLogger < ::Logster::Logger
@@ -8,9 +8,7 @@ module Logster
 
     def report_to_store(severity, progname, message, opts = {})
       opts[:backtrace] ||= caller.join("\n")
-      Logster::Scheduler.schedule do
-        super(severity, progname, message, opts)
-      end
+      Logster::Scheduler.schedule { super(severity, progname, message, opts) }
     end
   end
 end

--- a/lib/logster/group.rb
+++ b/lib/logster/group.rb
@@ -17,12 +17,13 @@ module Logster
 
     def self.from_json(json)
       hash = JSON.parse(json)
-      group = new(
-        hash["key"],
-        hash["messages_keys"],
-        timestamp: hash["timestamp"] || 0,
-        count: hash["count"] || 0
-      )
+      group =
+        new(
+          hash["key"],
+          hash["messages_keys"],
+          timestamp: hash["timestamp"] || 0,
+          count: hash["count"] || 0,
+        )
       group.changed = false
       group
     end
@@ -32,12 +33,7 @@ module Logster
     end
 
     def to_h
-      {
-        key: @key,
-        messages_keys: @messages_keys,
-        timestamp: @timestamp,
-        count: @count
-      }
+      { key: @key, messages_keys: @messages_keys, timestamp: @timestamp, count: @count }
     end
 
     def to_h_web
@@ -47,7 +43,7 @@ module Logster
         timestamp: @timestamp,
         messages: @messages,
         severity: -1,
-        group: true
+        group: true,
       }
     end
 
@@ -111,14 +107,15 @@ module Logster
       self.class.max_size
     end
 
-    GroupWeb = Struct.new(*%i[regex count timestamp messages row_id]) do
-      def to_json(opts = nil)
-        JSON.fast_generate(self.to_h.merge(severity: -1, group: true), opts)
-      end
+    GroupWeb =
+      Struct.new(*%i[regex count timestamp messages row_id]) do
+        def to_json(opts = nil)
+          JSON.fast_generate(self.to_h.merge(severity: -1, group: true), opts)
+        end
 
-      def key
-        self.regex # alias for testing convenience
+        def key
+          self.regex # alias for testing convenience
+        end
       end
-    end
   end
 end

--- a/lib/logster/ignore_pattern.rb
+++ b/lib/logster/ignore_pattern.rb
@@ -2,7 +2,6 @@
 
 module Logster
   class IgnorePattern
-
     def initialize(message_pattern = nil, env_patterns = nil)
       @msg_match = message_pattern
       @env_match = env_patterns
@@ -44,7 +43,7 @@ module Logster
         else
           false
         end
-        else
+      else
         false
       end
     end

--- a/lib/logster/middleware/debug_exceptions.rb
+++ b/lib/logster/middleware/debug_exceptions.rb
@@ -13,15 +13,17 @@ class Logster::Middleware::DebugExceptions < ActionDispatch::DebugExceptions
 
     exception = wrapper.exception
 
-    Logster.config.current_context.call(env) do
-      Logster.logger.add_with_opts(
-        ::Logger::Severity::FATAL,
-        "#{exception.class} (#{exception})\n#{wrapper.application_trace.join("\n")}",
-        "web-exception",
-        backtrace: wrapper.full_trace.join("\n"),
-        env: env
-      )
-    end
-
+    Logster
+      .config
+      .current_context
+      .call(env) do
+        Logster.logger.add_with_opts(
+          ::Logger::Severity::FATAL,
+          "#{exception.class} (#{exception})\n#{wrapper.application_trace.join("\n")}",
+          "web-exception",
+          backtrace: wrapper.full_trace.join("\n"),
+          env: env,
+        )
+      end
   end
 end

--- a/lib/logster/pattern.rb
+++ b/lib/logster/pattern.rb
@@ -4,7 +4,8 @@ module Logster
   class Pattern
     @child_classes = []
 
-    class PatternError < StandardError; end
+    class PatternError < StandardError
+    end
 
     def self.inherited(subclass)
       @child_classes << subclass
@@ -23,7 +24,7 @@ module Logster
       return string if Regexp === string
       return unless String === string
       if string[0] == "/"
-        return unless string =~ /\/(.+)\/(.*)/
+        return unless string =~ %r{/(.+)/(.*)}
         string = $1
         flag = Regexp::IGNORECASE if $2 && $2.include?("i")
       end
@@ -34,11 +35,7 @@ module Logster
 
     def self.find_all(raw: false, store: Logster.store)
       patterns = store.get_patterns(set_name) || []
-      unless raw
-        patterns.map! do |p|
-          parse_pattern(p)
-        end
-      end
+      patterns.map! { |p| parse_pattern(p) } unless raw
       patterns.compact!
       patterns
     end

--- a/lib/logster/rails/railtie.rb
+++ b/lib/logster/rails/railtie.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 module Logster::Rails
-
   # this magically registers logster.js in the asset pipeline
   class Engine < Rails::Engine
   end
@@ -9,14 +8,14 @@ module Logster::Rails
   def self.set_logger(config)
     return unless Logster.config.environments.include?(Rails.env.to_sym)
 
-    require 'logster/middleware/debug_exceptions'
-    require 'logster/middleware/reporter'
+    require "logster/middleware/debug_exceptions"
+    require "logster/middleware/reporter"
 
     store = Logster.store ||= Logster::RedisStore.new
     store.level = Logger::Severity::WARN if Rails.env.production?
 
     if Rails.env.development?
-      require 'logster/defer_logger'
+      require "logster/defer_logger"
       logger = Logster::DeferLogger.new(store)
     else
       logger = Logster::Logger.new(store)
@@ -37,9 +36,12 @@ module Logster::Rails
       end
 
       if Rails::VERSION::MAJOR == 3
-        app.middleware.insert_before ActionDispatch::DebugExceptions, Logster::Middleware::DebugExceptions
+        app.middleware.insert_before ActionDispatch::DebugExceptions,
+                                     Logster::Middleware::DebugExceptions
       else
-        app.middleware.insert_before ActionDispatch::DebugExceptions, Logster::Middleware::DebugExceptions, Rails.application
+        app.middleware.insert_before ActionDispatch::DebugExceptions,
+                                     Logster::Middleware::DebugExceptions,
+                                     Rails.application
       end
 
       app.middleware.delete ActionDispatch::DebugExceptions
@@ -47,18 +49,13 @@ module Logster::Rails
 
       unless Logster.config.application_version
         git_version = `cd #{Rails.root} && git rev-parse --short HEAD 2> /dev/null`
-        if git_version.present?
-          Logster.config.application_version = git_version.strip
-        end
+        Logster.config.application_version = git_version.strip if git_version.present?
       end
     end
   end
 
   class Railtie < ::Rails::Railtie
-
-    config.before_initialize do
-      Logster::Rails.set_logger(config)
-    end
+    config.before_initialize { Logster::Rails.set_logger(config) }
 
     initializer "logster.configure_rails_initialization" do |app|
       Logster::Rails.initialize!(app)

--- a/lib/logster/redis_rate_limiter.rb
+++ b/lib/logster/redis_rate_limiter.rb
@@ -81,12 +81,7 @@ module Logster
     private
 
     def self.key_prefix(redis_prefix)
-      if redis_prefix
-        "#{redis_prefix.call}:#{PREFIX}"
-      else
-        PREFIX
-      end
-
+      redis_prefix ? "#{redis_prefix.call}:#{PREFIX}" : PREFIX
     end
 
     def key_prefix
@@ -96,7 +91,7 @@ module Logster
     def mget_keys(bucket_num)
       keys = @mget_keys.dup
       keys.delete_at(bucket_num)
-      keys.map { |key| "'#{key}'" }.join(', ')
+      keys.map { |key| "'#{key}'" }.join(", ")
     end
 
     def bucket_number(time)

--- a/lib/logster/scheduler.rb
+++ b/lib/logster/scheduler.rb
@@ -31,11 +31,7 @@ module Logster
     private
 
     def start_thread
-      @mutex.synchronize do
-        if !@thread&.alive?
-          @thread = Thread.new { do_work }
-        end
-      end
+      @mutex.synchronize { @thread = Thread.new { do_work } if !@thread&.alive? }
     end
 
     def do_work

--- a/lib/logster/suppression_pattern.rb
+++ b/lib/logster/suppression_pattern.rb
@@ -24,12 +24,14 @@ module Logster
     def retro_delete_messages
       keys = []
       grouping_keys = []
-      @store.get_all_messages(with_env: false).each do |message|
-        if message =~ self.pattern
-          keys << message.key
-          grouping_keys << message.grouping_key
+      @store
+        .get_all_messages(with_env: false)
+        .each do |message|
+          if message =~ self.pattern
+            keys << message.key
+            grouping_keys << message.grouping_key
+          end
         end
-      end
       @store.bulk_delete(keys, grouping_keys) if keys.size > 0 && grouping_keys.size > 0
     end
   end

--- a/lib/logster/web.rb
+++ b/lib/logster/web.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'logster/middleware/viewer'
+require "logster/middleware/viewer"
 
 class Logster::Web
   class FourOhFour

--- a/logster.gemspec
+++ b/logster.gemspec
@@ -1,30 +1,29 @@
 # coding: utf-8
 # frozen_string_literal: true
 
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'logster/version'
+require "logster/version"
 
 Gem::Specification.new do |spec|
-  spec.name          = "logster"
-  spec.version       = Logster::VERSION
-  spec.authors       = ["Sam Saffron"]
-  spec.email         = ["sam.saffron@gmail.com"]
-  spec.summary       = %q{UI for viewing logs in Rack}
-  spec.description   = %q{UI for viewing logs in Rack}
-  spec.homepage      = "https://github.com/discourse/logster"
-  spec.license       = "MIT"
+  spec.name = "logster"
+  spec.version = Logster::VERSION
+  spec.authors = ["Sam Saffron"]
+  spec.email = ["sam.saffron@gmail.com"]
+  spec.summary = "UI for viewing logs in Rack"
+  spec.description = "UI for viewing logs in Rack"
+  spec.homepage = "https://github.com/discourse/logster"
+  spec.license = "MIT"
 
   spec.required_ruby_version = ">= 2.5.0"
 
-  files =
-    `git ls-files -z`.split("\x0").reject { |f| f.start_with?(/website|bin/) }
+  files = `git ls-files -z`.split("\x0").reject { |f| f.start_with?(/website|bin/) }
   files += Dir.glob("assets/javascript/*")
   files += Dir.glob("assets/stylesheets/*")
   spec.files = files
 
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
+  spec.executables = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  spec.test_files = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
   # NOTE dependency on rack is not explicit, this enables us to use
@@ -39,4 +38,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "timecop"
   spec.add_development_dependency "byebug", "~> 11.1.0"
   spec.add_development_dependency "rubocop-discourse", "~> 2.4.1"
+  spec.add_development_dependency "syntax_tree"
 end

--- a/test/examples/test_sidekiq_reporter_example.rb
+++ b/test/examples/test_sidekiq_reporter_example.rb
@@ -1,13 +1,12 @@
 # frozen_string_literal: true
 
-require_relative '../test_helper'
-require 'logster/logger'
-require 'logster/redis_store'
-require 'logger'
-require 'examples/sidekiq_logster_reporter'
+require_relative "../test_helper"
+require "logster/logger"
+require "logster/redis_store"
+require "logger"
+require "examples/sidekiq_logster_reporter"
 
 class TestSidekiqReporter < MiniTest::Test
-
   def setup
     Logster.store = @store = Logster::RedisStore.new(Redis.new)
     Logster.logger = @logger = Logster::Logger.new(Logster.store)
@@ -38,11 +37,11 @@ class TestSidekiqReporter < MiniTest::Test
     # A backtrace is joined()
     assert_equal(trace.join("\n"), report.backtrace)
     # The backtrace is deleted from the env
-    assert_nil(report.env['backtrace'])
+    assert_nil(report.env["backtrace"])
     assert_nil(report.env[:backtrace])
 
     # The env is in the report
-    assert_equal("Test", report.env['code'])
-    assert_equal(20, report.env['params']['article_id'])
+    assert_equal("Test", report.env["code"])
+    assert_equal(20, report.env["params"]["article_id"])
   end
 end

--- a/test/fake_data/generate.rb
+++ b/test/fake_data/generate.rb
@@ -1,12 +1,23 @@
 # frozen_string_literal: true
 
-require 'redis'
-require 'logster'
+require "redis"
+require "logster"
 
 Logster.config.allow_grouping = true
 Logster.config.application_version = "ABC123"
 Logster.store = Logster::RedisStore.new
 
 10.times do
-  Logster.store.report(Logger::WARN, "application", "test warning", backtrace: "method1\nmethod2", env: { something: ["hello world", "hello places"], another: { thing: "something else" } })
+  Logster.store.report(
+    Logger::WARN,
+    "application",
+    "test warning",
+    backtrace: "method1\nmethod2",
+    env: {
+      something: ["hello world", "hello places"],
+      another: {
+        thing: "something else",
+      },
+    },
+  )
 end

--- a/test/logster/middleware/test_reporter.rb
+++ b/test/logster/middleware/test_reporter.rb
@@ -1,12 +1,11 @@
 # frozen_string_literal: true
 
-require_relative '../../test_helper'
-require 'rack'
-require 'logster/redis_store'
-require 'logster/middleware/reporter'
+require_relative "../../test_helper"
+require "rack"
+require "logster/redis_store"
+require "logster/middleware/reporter"
 
 class TestReporter < Minitest::Test
-
   def setup
     Logster.store = Logster::RedisStore.new
     Logster.store.clear_all
@@ -72,11 +71,14 @@ class TestReporter < Minitest::Test
     assert_equal(1, Logster.store.count)
 
     reporter = Logster::Middleware::Reporter.new(nil)
-    env = Rack::MockRequest.env_for("/logs/report_js_error?message=hello2", "REMOTE_ADDR" => "100.1.1.2")
+    env =
+      Rack::MockRequest.env_for(
+        "/logs/report_js_error?message=hello2",
+        "REMOTE_ADDR" => "100.1.1.2",
+      )
     status, = reporter.call(env)
 
     assert_equal(200, status)
     assert_equal(2, Logster.store.count)
   end
-
 end

--- a/test/logster/test_base_store.rb
+++ b/test/logster/test_base_store.rb
@@ -1,11 +1,10 @@
 # frozen_string_literal: true
 
-require_relative '../test_helper'
-require 'logster/base_store'
-require 'logster/ignore_pattern'
+require_relative "../test_helper"
+require "logster/base_store"
+require "logster/ignore_pattern"
 
 class TestBaseStore < Minitest::Test
-
   def setup
     @store = Logster::TestStore.new
     @store.clear_all
@@ -18,7 +17,7 @@ class TestBaseStore < Minitest::Test
   def test_report_skip_empty
     @store.skip_empty = true
     @store.report(Logger::WARN, "test", nil)
-    @store.report(Logger::WARN, "test", '')
+    @store.report(Logger::WARN, "test", "")
     @store.report(Logger::WARN, "test", "foo") #
     @store.skip_empty = false
     @store.report(Logger::WARN, "test", nil) #
@@ -39,30 +38,40 @@ class TestBaseStore < Minitest::Test
 
   def test_report_skip_ignore
     @store.report(Logger::WARN, "test", "Can't verify CSRF token authenticity")
-    @store.report(Logger::FATAL, "test", "ActiveRecord::RecordNotFound (Couldn't find Upload with 'id'=9947)")
+    @store.report(
+      Logger::FATAL,
+      "test",
+      "ActiveRecord::RecordNotFound (Couldn't find Upload with 'id'=9947)",
+    )
     @store.report(Logger::WARN, "test", "B")
     @store.ignore = [
-        /^ActiveRecord::RecordNotFound \(Couldn't find Upload/,
-        /^Can't verify CSRF token authenticity/
+      /^ActiveRecord::RecordNotFound \(Couldn't find Upload/,
+      /^Can't verify CSRF token authenticity/,
     ]
     @store.report(Logger::WARN, "test", "Can't verify CSRF token authenticity")
-    @store.report(Logger::FATAL, "test", "ActiveRecord::RecordNotFound (Couldn't find Upload with 'id'=9947)")
-    @store.report(Logger::FATAL, "test", "ActiveRecord::RecordNotFound (Couldn't find Upload with 'id'=9489+78946947)")
+    @store.report(
+      Logger::FATAL,
+      "test",
+      "ActiveRecord::RecordNotFound (Couldn't find Upload with 'id'=9947)",
+    )
+    @store.report(
+      Logger::FATAL,
+      "test",
+      "ActiveRecord::RecordNotFound (Couldn't find Upload with 'id'=9489+78946947)",
+    )
     @store.report(Logger::WARN, "test", "B")
 
     assert_equal(4, @store.count)
   end
 
   def test_ignore_pattern_basic
-    @store.ignore = [
-        Logster::IgnorePattern.new(nil, username: 'CausingErrors')
-    ]
+    @store.ignore = [Logster::IgnorePattern.new(nil, username: "CausingErrors")]
     @store.report(Logger::WARN, "test", "Foobar") #
-    @store.report(Logger::WARN, "test", "Foobar", env: { username: 'CausingErrors' })
+    @store.report(Logger::WARN, "test", "Foobar", env: { username: "CausingErrors" })
     @store.report(Logger::WARN, "test", "Foobar", env: nil)
-    @store.report(Logger::WARN, "test", "Something Else", env: { username: 'CausingErrors' })
-    @store.report(Logger::WARN, "test", "Something Else", env: { 'username' => 'CausingErrors' })
-    @store.report(Logger::WARN, "test", "Something Else", env: { username: 'GoodPerson' }) #
+    @store.report(Logger::WARN, "test", "Something Else", env: { username: "CausingErrors" })
+    @store.report(Logger::WARN, "test", "Something Else", env: { "username" => "CausingErrors" })
+    @store.report(Logger::WARN, "test", "Something Else", env: { username: "GoodPerson" }) #
     @store.report(Logger::WARN, "test", "Can't verify CSRF token authenticity") #
 
     assert_equal(4, @store.count)
@@ -70,37 +79,47 @@ class TestBaseStore < Minitest::Test
 
   def test_ignore_pattern_real
     @store.ignore = [
-        /^ActionController::RoutingError \(No route matches/,
-        Logster::IgnorePattern.new("Can't verify CSRF token authenticity", REQUEST_URI: /\/trackback\/$/)
+      /^ActionController::RoutingError \(No route matches/,
+      Logster::IgnorePattern.new(
+        "Can't verify CSRF token authenticity",
+        REQUEST_URI: %r{/trackback/$},
+      ),
     ]
     # blocked
-    @store.report(Logger::WARN, "whatever", "Can't verify CSRF token authenticity",
-        env: {
-            HTTP_HOST: 'meta.discourse.org',
-            REQUEST_URI: '/t/use-more-standard-smiley-codes-instead-of-smile/1822/trackback/',
-            REQUEST_METHOD: 'POST',
-            HTTP_USER_AGENT: 'Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1)',
-            params: {
-                title: 'Something Spammy',
-                url: 'http://spam.example.net/whatever/spam.html',
-                excerpt: 'http://spam.example.com/pdf/blahblah.html free viagra',
-                blog_name: 'get free spam for cheap'
-            }
-        }
+    @store.report(
+      Logger::WARN,
+      "whatever",
+      "Can't verify CSRF token authenticity",
+      env: {
+        HTTP_HOST: "meta.discourse.org",
+        REQUEST_URI: "/t/use-more-standard-smiley-codes-instead-of-smile/1822/trackback/",
+        REQUEST_METHOD: "POST",
+        HTTP_USER_AGENT: "Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1)",
+        params: {
+          title: "Something Spammy",
+          url: "http://spam.example.net/whatever/spam.html",
+          excerpt: "http://spam.example.com/pdf/blahblah.html free viagra",
+          blog_name: "get free spam for cheap",
+        },
+      },
     )
     # logged
-    @store.report(Logger::WARN, "whatever", "Can't verify CSRF token authenticity",
-        env: {
-            HTTP_HOST: 'meta.discourse.org',
-            REQUEST_URI: '/session',
-            REQUEST_METHOD: 'POST',
-            HTTP_USER_AGENT: 'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/35.0.1916.153 Safari/537.36',
-            params: {
-                username: 'user',
-                password: 'password',
-                form_authenticity_token: 'incorrect'
-            }
-        }
+    @store.report(
+      Logger::WARN,
+      "whatever",
+      "Can't verify CSRF token authenticity",
+      env: {
+        HTTP_HOST: "meta.discourse.org",
+        REQUEST_URI: "/session",
+        REQUEST_METHOD: "POST",
+        HTTP_USER_AGENT:
+          "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/35.0.1916.153 Safari/537.36",
+        params: {
+          username: "user",
+          password: "password",
+          form_authenticity_token: "incorrect",
+        },
+      },
     )
     assert_equal(1, @store.count)
   end
@@ -128,7 +147,16 @@ class TestBaseStore < Minitest::Test
     assert_equal(error.backtrace.join("\n"), message.backtrace)
 
     # Via env takes priority
-    message = @store.report(Logger::WARN, "test", "C", backtrace: "Garbage", env: { backtrace: error.backtrace })
+    message =
+      @store.report(
+        Logger::WARN,
+        "test",
+        "C",
+        backtrace: "Garbage",
+        env: {
+          backtrace: error.backtrace,
+        },
+      )
     assert_equal(error.backtrace.join("\n"), message.backtrace)
 
     # Backtrace is always a string
@@ -143,7 +171,7 @@ class TestBaseStore < Minitest::Test
     assert_kind_of(String, message.backtrace)
 
     # Arrays are turned into strings via join \n
-    message = @store.report(Logger::WARN, "test", "H", backtrace: ["Foo", "Bar"])
+    message = @store.report(Logger::WARN, "test", "H", backtrace: %w[Foo Bar])
     assert_equal("Foo\nBar", message.backtrace)
   end
 
@@ -166,12 +194,12 @@ class TestBaseStore < Minitest::Test
   def test_log_message_is_truncated_when_above_maximum_message_length
     orig = Logster.config.maximum_message_length
     Logster.config.maximum_message_length = 300
-    msg = @store.report(Logger::WARN, '', 'a' * 400)
+    msg = @store.report(Logger::WARN, "", "a" * 400)
     # 3 is the ... at the end to indicate truncated message
     assert_equal(300 + 3, msg.message.size)
 
     Logster.config.maximum_message_length = 100
-    msg = @store.report(Logger::WARN, '', 'a' * 200)
+    msg = @store.report(Logger::WARN, "", "a" * 200)
     assert_equal(100 + 3, msg.message.size)
   ensure
     Logster.config.maximum_message_length = orig
@@ -182,22 +210,15 @@ class TestBaseStore < Minitest::Test
     other_store = Logster::TestStore.new
     other_logger = Logster::Logger.new(other_store)
     logger.chain(other_logger)
-    logger.add(Logger::WARN, "this is warning", '', { env: { backtrace: '11' } })
+    logger.add(Logger::WARN, "this is warning", "", { env: { backtrace: "11" } })
     [@store, other_store].each do |store|
-      assert_equal('11', store.reported.first.backtrace)
+      assert_equal("11", store.reported.first.backtrace)
       refute_includes(store.reported.first.env.keys.map(&:to_sym), :backtrace)
     end
   end
 
   def test_envs_with_invalid_encoding_dont_raise_errors
-    msg = @store.report(
-      Logger::WARN,
-      '',
-      'me have invalid encoding',
-      env: {
-        axe: "a\xF1xasa"
-      }
-    )
+    msg = @store.report(Logger::WARN, "", "me have invalid encoding", env: { axe: "a\xF1xasa" })
     assert_equal("a�xasa", msg.env[:axe])
   end
 end

--- a/test/logster/test_cache.rb
+++ b/test/logster/test_cache.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require_relative '../test_helper'
-require 'logster/cache'
+require_relative "../test_helper"
+require "logster/cache"
 
 class TestCache < Minitest::Test
   def setup
@@ -9,11 +9,7 @@ class TestCache < Minitest::Test
   end
 
   def test_cache_works
-    prc = Proc.new do |key, value|
-      @cache.fetch(key) do
-        value
-      end
-    end
+    prc = Proc.new { |key, value| @cache.fetch(key) { value } }
     value = "I should be retured"
     assert_equal(value, prc.call(:key1, value))
     cached_value = value
@@ -23,7 +19,7 @@ class TestCache < Minitest::Test
     assert_equal(value2, prc.call(:key2, value2))
 
     value = value2 = "Now I should be returned"
-    Process.stub :clock_gettime,  Process.clock_gettime(Process::CLOCK_MONOTONIC) + 6 do
+    Process.stub :clock_gettime, Process.clock_gettime(Process::CLOCK_MONOTONIC) + 6 do
       assert_equal(value, prc.call(:key1, value))
       assert_equal(value2, prc.call(:key2, value2))
     end
@@ -31,9 +27,7 @@ class TestCache < Minitest::Test
 
   def test_cache_can_be_cleared
     value = "cached"
-    prc = Proc.new do |key, val|
-      @cache.fetch(key) { val }
-    end
+    prc = Proc.new { |key, val| @cache.fetch(key) { val } }
     assert_equal(value, prc.call(:key1, value))
     assert_equal("v2", prc.call(:key2, "v2"))
 

--- a/test/logster/test_defer_logger.rb
+++ b/test/logster/test_defer_logger.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-require_relative '../test_helper'
-require 'logster/defer_logger'
-require 'logster/logger'
+require_relative "../test_helper"
+require "logster/defer_logger"
+require "logster/logger"
 
 class TestDeferLogger < Minitest::Test
   def setup

--- a/test/logster/test_group.rb
+++ b/test/logster/test_group.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-require_relative '../test_helper'
-require 'logster/group'
-require 'logster/message'
+require_relative "../test_helper"
+require "logster/group"
+require "logster/message"
 
 class TestGroup < MiniTest::Test
   def test_changed_is_true_for_new_instances
@@ -11,12 +11,13 @@ class TestGroup < MiniTest::Test
 
   def test_from_json_works_correctly
     time = (Time.now.to_f * 1000).to_i - 5000
-    json = JSON.generate(
-      key: '/somekey/',
-      messages_keys: [111, 222, 333].map(&:to_s),
-      timestamp: time,
-      count: 3
-    )
+    json =
+      JSON.generate(
+        key: "/somekey/",
+        messages_keys: [111, 222, 333].map(&:to_s),
+        timestamp: time,
+        count: 3,
+      )
     group = Logster::Group.from_json(json)
     refute group.changed?
     assert_equal 3, group.count
@@ -34,7 +35,7 @@ class TestGroup < MiniTest::Test
     assert_equal 1, group.count
 
     msg2 = get_message
-    msg2.timestamp -= 10000
+    msg2.timestamp -= 10_000
     group.add_message(msg2)
     assert_equal 2, group.count
     assert_equal msg1.timestamp, group.timestamp
@@ -42,12 +43,7 @@ class TestGroup < MiniTest::Test
 
   def test_adding_multiple_messages_works_correctly
     group = get_group
-    messages = [
-      get_message(10),
-      get_message(5),
-      get_message(74),
-      get_message(26)
-    ]
+    messages = [get_message(10), get_message(5), get_message(74), get_message(26)]
     messages << messages[0]
     group.messages = messages
     group.count = 4
@@ -66,7 +62,7 @@ class TestGroup < MiniTest::Test
       get_message(74),
       get_message(26),
       get_message(44),
-      get_message(390)
+      get_message(390),
     ]
     messages.each { |m| group.add_message(m) }
     # the count attr keeps track of the number of messages
@@ -91,6 +87,6 @@ class TestGroup < MiniTest::Test
   end
 
   def get_message(timestamp = nil)
-    Logster::Message.new(0, '', 'testmessage', timestamp)
+    Logster::Message.new(0, "", "testmessage", timestamp)
   end
 end

--- a/test/logster/test_ignore_pattern.rb
+++ b/test/logster/test_ignore_pattern.rb
@@ -1,10 +1,9 @@
 # frozen_string_literal: true
 
-require_relative '../test_helper'
-require 'logster/ignore_pattern'
+require_relative "../test_helper"
+require "logster/ignore_pattern"
 
 class TestIgnorePattern < Minitest::Test
-
   def test_string_message_pattern
     msg = Logster::Message.new(Logger::WARN, "test", "my error (oh no!)")
     msg_frog = Logster::Message.new(Logger::WARN, "test", "a frog")

--- a/test/logster/test_logger.rb
+++ b/test/logster/test_logger.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-require_relative '../test_helper'
-require 'logster/logger'
-require 'logger'
+require_relative "../test_helper"
+require "logster/logger"
+require "logger"
 
 class TestStore < Logster::BaseStore
   attr_accessor :calls
@@ -13,7 +13,6 @@ class TestStore < Logster::BaseStore
 end
 
 class TestLogger < Minitest::Test
-
   def setup
     @store = TestStore.new
     @logger = Logster::Logger.new(@store)
@@ -35,9 +34,7 @@ class TestLogger < Minitest::Test
     @logger.override_level = 2
 
     @logger.add(0, "test", "prog", backtrace: "backtrace", env: { a: "x" })
-    Thread.new do
-      @logger.add(0, "test", "prog", backtrace: "backtrace", env: { a: "x" })
-    end.join
+    Thread.new { @logger.add(0, "test", "prog", backtrace: "backtrace", env: { a: "x" }) }.join
 
     @logger.override_level = nil
     @logger.add(0, "test", "prog", backtrace: "backtrace", env: { a: "x" })
@@ -64,9 +61,7 @@ class TestLogger < Minitest::Test
 
     @logger.add(0, "test", "prog", backtrace: "backtrace", env: { a: "x" })
 
-    [@store, @other_store].each do |store|
-      assert_equal "backtrace", store.calls[0][3][:backtrace]
-    end
+    [@store, @other_store].each { |store| assert_equal "backtrace", store.calls[0][3][:backtrace] }
   end
 
   def test_add_with_one_argument
@@ -76,7 +71,8 @@ class TestLogger < Minitest::Test
     assert_equal "test", @store.calls.first[2]
   end
 
-  class NewLogger < Logster::Logger; end
+  class NewLogger < Logster::Logger
+  end
 
   def test_inherited_logger_backtrace_with_chain
     @other_store = TestStore.new
@@ -85,9 +81,7 @@ class TestLogger < Minitest::Test
 
     @logger.add(0, "test", "prog", backtrace: "backtrace", env: { a: "x" })
 
-    [@store, @other_store].each do |store|
-      assert_equal "backtrace", store.calls[0][3][:backtrace]
-    end
+    [@store, @other_store].each { |store| assert_equal "backtrace", store.calls[0][3][:backtrace] }
   end
 
   def test_progname_parameter

--- a/test/logster/test_message.rb
+++ b/test/logster/test_message.rb
@@ -1,15 +1,14 @@
 # frozen_string_literal: true
 
-require_relative '../test_helper'
-require 'logster/message'
+require_relative "../test_helper"
+require "logster/message"
 
 class TestMessage < MiniTest::Test
-
   def test_merge_similar
-    msg1 = Logster::Message.new(0, '', 'test', 10)
+    msg1 = Logster::Message.new(0, "", "test", 10)
     msg1.populate_from_env(a: "1", b: "2")
 
-    msg2 = Logster::Message.new(0, '', 'test', 20)
+    msg2 = Logster::Message.new(0, "", "test", 20)
     msg2.populate_from_env(a: "2", c: "3")
     assert_equal(msg2.grouping_key, msg1.grouping_key)
     msg1.merge_similar_message(msg2)
@@ -21,35 +20,35 @@ class TestMessage < MiniTest::Test
 
   def test_populate_from_env_will_add_time_to_env_unless_it_already_exists
     t = (Time.now.to_f * 1000).to_i
-    msg = Logster::Message.new(0, '', 'test', t)
+    msg = Logster::Message.new(0, "", "test", t)
     msg.populate_from_env({})
     assert_equal(t, msg.env["time"])
 
-    msg = Logster::Message.new(0, '', 'test', t)
+    msg = Logster::Message.new(0, "", "test", t)
     msg.populate_from_env(time: 5)
     assert_nil(msg.env["time"])
     assert_equal(5, msg.env[:time])
 
-    msg = Logster::Message.new(0, '', 'test', t)
+    msg = Logster::Message.new(0, "", "test", t)
     msg.populate_from_env("time" => 6)
     assert_equal(6, msg.env["time"])
     assert_nil(msg.env[:time])
 
-    msg = Logster::Message.new(0, '', 'test', t)
+    msg = Logster::Message.new(0, "", "test", t)
     msg.populate_from_env([{ "time" => 6 }, { "time" => 8 }])
     assert_equal([6, 8], msg.env.map { |e| e["time"] })
     assert_equal([nil, nil], msg.env.map { |e| e[:time] })
 
-    msg = Logster::Message.new(0, '', 'test', t)
+    msg = Logster::Message.new(0, "", "test", t)
     msg.populate_from_env([{ dsd: 6 }, { dsd: 8 }])
     assert_equal([t, t], msg.env.map { |e| e["time"] })
   end
 
   def test_merge_messages_both_with_array_envs
-    msg1 = Logster::Message.new(0, '', 'test', 10)
+    msg1 = Logster::Message.new(0, "", "test", 10)
     msg1.env = [{ a: "aa", b: "bb" }, { c: "cc", d: "dd" }]
 
-    msg2 = Logster::Message.new(0, '', 'test', 20)
+    msg2 = Logster::Message.new(0, "", "test", 20)
     msg2.env = [{ e: "ee", f: "ff" }, { g: "gg", h: "hh" }]
 
     msg1.merge_similar_message(msg2)
@@ -57,10 +56,10 @@ class TestMessage < MiniTest::Test
   end
 
   def test_merge_messages_one_with_array_envs
-    msg1 = Logster::Message.new(0, '', 'test', 10)
+    msg1 = Logster::Message.new(0, "", "test", 10)
     msg1.env = { e: "ee", f: "ff" }
 
-    msg2 = Logster::Message.new(0, '', 'test', 20)
+    msg2 = Logster::Message.new(0, "", "test", 20)
     msg2.env = [{ a: "aa", b: "bb" }, { c: "cc", d: "dd" }]
 
     msg1.merge_similar_message(msg2)
@@ -69,11 +68,10 @@ class TestMessage < MiniTest::Test
 
   def test_adds_application_version
     Logster.config.application_version = "abc"
-    msg = Logster::Message.new(0, '', 'test', 10)
+    msg = Logster::Message.new(0, "", "test", 10)
     msg.populate_from_env({})
 
     assert_equal("abc", msg.env["application_version"])
-
   ensure
     Logster.config.application_version = nil
   end
@@ -81,7 +79,7 @@ class TestMessage < MiniTest::Test
   def test_use_full_hostname
     Logster::Message.instance_variable_set(:@hostname, nil)
     Logster.config.use_full_hostname = true
-    msg = Logster::Message.new(0, '', 'test', 10)
+    msg = Logster::Message.new(0, "", "test", 10)
     msg.populate_from_env({})
 
     assert_equal(`hostname -f`.strip!, msg.env["hostname"])
@@ -91,8 +89,8 @@ class TestMessage < MiniTest::Test
   end
 
   def test_merging_sums_count_for_both_messages
-    msg1 = Logster::Message.new(0, '', 'test', 10, count: 15)
-    msg2 = Logster::Message.new(0, '', 'test', 20, count: 13)
+    msg1 = Logster::Message.new(0, "", "test", 10, count: 15)
+    msg2 = Logster::Message.new(0, "", "test", 20, count: 13)
     msg2.env = {}
 
     assert_equal(msg1.grouping_key, msg2.grouping_key)
@@ -108,8 +106,8 @@ class TestMessage < MiniTest::Test
       message: "invalid encoding",
       env: {
         a: "bad_value",
-        b: ["bad_value"]
-      }
+        b: ["bad_value"],
+      },
     }
     json = hash.to_json.gsub("bad_value", "45\xC0\xBE")
     message = Logster::Message.from_json(json)
@@ -120,7 +118,7 @@ class TestMessage < MiniTest::Test
   end
 
   def test_populate_from_env_works_on_array
-    msg = Logster::Message.new(0, '', 'test', 10)
+    msg = Logster::Message.new(0, "", "test", 10)
     hash = { "custom_key" => "key" }
     msg.populate_from_env([hash])
 
@@ -130,9 +128,9 @@ class TestMessage < MiniTest::Test
   end
 
   def test_merging_envs_add_new_envs_to_buffer
-    msg1 = Logster::Message.new(0, '', 'test', 10, count: 50)
+    msg1 = Logster::Message.new(0, "", "test", 10, count: 50)
     msg1.env = 50.times.map { |n| { a: n } }
-    msg2 = Logster::Message.new(0, '', 'test', 20, count: 13)
+    msg2 = Logster::Message.new(0, "", "test", 20, count: 13)
     msg2.env = 13.times.map { |n| { b: n } }
 
     assert_equal(msg1.grouping_key, msg2.grouping_key)
@@ -159,7 +157,7 @@ class TestMessage < MiniTest::Test
   end
 
   def test_drop_redundant_envs
-    message = Logster::Message.new(Logger::WARN, '', 'message')
+    message = Logster::Message.new(Logger::WARN, "", "message")
     message.env = [{ a: 4 }] * 10
     assert_equal(10, message.env.size)
     message.drop_redundant_envs(5)
@@ -172,7 +170,7 @@ class TestMessage < MiniTest::Test
   end
 
   def test_apply_env_size_limit_keeps_as_many_keys_as_possible
-    message = Logster::Message.new(Logger::WARN, '', 'message', 1)
+    message = Logster::Message.new(Logger::WARN, "", "message", 1)
     env = { a: 1, bb: 22, ccc: 333 }
     message.env = env.dup
     message.apply_env_size_limit(24)
@@ -207,7 +205,7 @@ class TestMessage < MiniTest::Test
       /var/www/discourse/lib/scheduler/defer.rb:79:in `block (2 levels) in start_thread'
     TEXT
     gems_dir = "/var/www/discourse/vendor/bundle/ruby/2.6.0/gems/"
-    message = Logster::Message.new(Logger::WARN, '', 'message', 1)
+    message = Logster::Message.new(Logger::WARN, "", "message", 1)
 
     message.backtrace = backtrace.dup
     assert_operator(message.to_json(exclude_env: true).bytesize, :>=, 500)
@@ -229,7 +227,7 @@ class TestMessage < MiniTest::Test
       rails_multisite-2.0.7/lib/rails_multisite/connection_management.rb:60:in `with_connection'
       /var/www/discourse
     TEXT
-    message = Logster::Message.new(Logger::WARN, '', 'message', 1)
+    message = Logster::Message.new(Logger::WARN, "", "message", 1)
     message.backtrace = backtrace.dup
     assert_operator(message.to_json(exclude_env: true).bytesize, :>=, 350)
     message.apply_message_size_limit(350)
@@ -239,7 +237,7 @@ class TestMessage < MiniTest::Test
 
   def test_truncate_backtrace_shouldnt_corrupt_backtrace_when_it_contains_multibytes_characters
     backtrace = "aहa"
-    message = Logster::Message.new(Logger::WARN, '', 'message', 1)
+    message = Logster::Message.new(Logger::WARN, "", "message", 1)
     message.backtrace = backtrace.dup
     message.truncate_backtrace(3)
     assert_equal("a", message.backtrace)
@@ -254,7 +252,7 @@ class TestMessage < MiniTest::Test
   end
 
   def test_apply_message_size_limit_doesnt_remove_backtrace_entirely
-    message = Logster::Message.new(Logger::WARN, '', 'message', 1)
+    message = Logster::Message.new(Logger::WARN, "", "message", 1)
     message.backtrace = "a" * 1000
     assert_operator(message.to_json(exclude_env: true).bytesize, :>=, 500)
     message.apply_message_size_limit(500)
@@ -263,7 +261,7 @@ class TestMessage < MiniTest::Test
   end
 
   def test_apply_message_size_limit_doesnt_hang_forever_and_doesnt_remove_backtrace_entirely
-    message = Logster::Message.new(Logger::WARN, '', 'message', 1)
+    message = Logster::Message.new(Logger::WARN, "", "message", 1)
     message.backtrace = "aa" * 100
     message.apply_message_size_limit(10)
     assert_equal(("aa" * 100).size, message.backtrace.size)

--- a/test/logster/test_pattern.rb
+++ b/test/logster/test_pattern.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-require_relative '../test_helper'
-require 'logster/redis_store'
-require 'logster/pattern'
+require_relative "../test_helper"
+require "logster/redis_store"
+require "logster/pattern"
 
 class TestPattern < Minitest::Test
   class FakePattern < Logster::Pattern
@@ -90,22 +90,16 @@ class TestPattern < Minitest::Test
   def test_save_works_correctly
     bad_patterns = ["/bruken", nil, "[a-z", "/(osa|sss{1/"]
     bad_patterns.each do |p|
-      assert_raises(Logster::Pattern::PatternError) do
-        FakePattern.new(p).save
-      end
+      assert_raises(Logster::Pattern::PatternError) { FakePattern.new(p).save }
     end
     assert_equal(0, FakePattern.find_all.size)
 
     good_patterns = ["/logster/i", /logster/, "sssd", "(ccx|tqe){1,5}", "logster"]
-    good_patterns.each do |p|
-      FakePattern.new(p).save
-    end
+    good_patterns.each { |p| FakePattern.new(p).save }
     results = FakePattern.find_all
     assert_equal(4, results.size) # 4 because /logster/ and logster are the same
     good_patterns_regex = [/logster/i, /logster/, /sssd/, /(ccx|tqe){1,5}/]
-    results.each do |p|
-      assert_includes(good_patterns_regex, p)
-    end
+    results.each { |p| assert_includes(good_patterns_regex, p) }
   end
 
   def test_modify_works_correctly
@@ -123,9 +117,7 @@ class TestPattern < Minitest::Test
     record = FakePattern.new(/LoGsTEr/)
     record.save
 
-    assert_raises(Logster::Pattern::PatternError) do
-      record.modify("/badReg")
-    end
+    assert_raises(Logster::Pattern::PatternError) { record.modify("/badReg") }
     all_patterns = FakePattern.find_all
     assert_equal(1, all_patterns.size)
     assert_equal(/LoGsTEr/, all_patterns.first)

--- a/test/logster/test_redis_rate_limiter.rb
+++ b/test/logster/test_redis_rate_limiter.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-require_relative '../test_helper'
-require 'logster/redis_store'
-require 'rack'
+require_relative "../test_helper"
+require "logster/redis_store"
+require "rack"
 
 class TestRedisRateLimiter < Minitest::Test
   def setup
@@ -19,13 +19,17 @@ class TestRedisRateLimiter < Minitest::Test
 
     @redis.set("dont_nuke", "1")
 
-    @rate_limiter = Logster::RedisRateLimiter.new(
-      @redis, [Logger::WARN], 8, 60, Proc.new { "prefix" }, Proc.new { called += 1 }
-    )
+    @rate_limiter =
+      Logster::RedisRateLimiter.new(
+        @redis,
+        [Logger::WARN],
+        8,
+        60,
+        Proc.new { "prefix" },
+        Proc.new { called += 1 },
+      )
 
-    9.times do
-      @rate_limiter.check(Logger::WARN)
-    end
+    9.times { @rate_limiter.check(Logger::WARN) }
 
     assert_equal 10, @rate_limiter.check(Logger::WARN)
 
@@ -40,7 +44,6 @@ class TestRedisRateLimiter < Minitest::Test
 
     assert_equal "1", @redis.get("dont_nuke")
     @redis.del("dont_nuke")
-
   end
 
   def test_check
@@ -48,9 +51,8 @@ class TestRedisRateLimiter < Minitest::Test
     Timecop.freeze(time)
     called = 0
 
-    @rate_limiter = Logster::RedisRateLimiter.new(
-      @redis, [Logger::WARN], 8, 60, nil, Proc.new { called += 1 }
-    )
+    @rate_limiter =
+      Logster::RedisRateLimiter.new(@redis, [Logger::WARN], 8, 60, nil, Proc.new { called += 1 })
 
     assert_equal(1, @rate_limiter.check(Logger::WARN))
     assert_redis_key(60, 0)
@@ -113,9 +115,15 @@ class TestRedisRateLimiter < Minitest::Test
     Timecop.freeze(time)
     called = 0
 
-    @rate_limiter = Logster::RedisRateLimiter.new(
-      @redis, [Logger::WARN, Logger::ERROR], 4, 60, nil, Proc.new { called += 1 }
-    )
+    @rate_limiter =
+      Logster::RedisRateLimiter.new(
+        @redis,
+        [Logger::WARN, Logger::ERROR],
+        4,
+        60,
+        nil,
+        Proc.new { called += 1 },
+      )
 
     assert_equal(1, @rate_limiter.check(Logger::WARN))
     assert_equal(2, @rate_limiter.check(Logger::ERROR))
@@ -170,16 +178,22 @@ class TestRedisRateLimiter < Minitest::Test
   def test_raw_connection
     time = Time.new(2015, 1, 1, 1, 1)
     Timecop.freeze(time)
-    @rate_limiter = Logster::RedisRateLimiter.new(@redis, [Logger::WARN], 1, 60, Proc.new { "lobster" })
+    @rate_limiter =
+      Logster::RedisRateLimiter.new(@redis, [Logger::WARN], 1, 60, Proc.new { "lobster" })
 
     assert_equal(1, @rate_limiter.check(Logger::WARN))
     assert_redis_key(60, 0)
 
     toggle = true
 
-    @rate_limiter = Logster::RedisRateLimiter.new(
-      @redis, [Logger::WARN], 1, 60, Proc.new { toggle ? 'lobster1' : 'lobster2' }
-    )
+    @rate_limiter =
+      Logster::RedisRateLimiter.new(
+        @redis,
+        [Logger::WARN],
+        1,
+        60,
+        Proc.new { toggle ? "lobster1" : "lobster2" },
+      )
 
     assert_includes(key, "lobster1")
 
@@ -188,7 +202,7 @@ class TestRedisRateLimiter < Minitest::Test
   end
 
   def test_retrieve_rate
-    time = Time.new(2015, 1, 1, 1 , 1)
+    time = Time.new(2015, 1, 1, 1, 1)
     Timecop.freeze(time)
 
     @rate_limiter = Logster::RedisRateLimiter.new(@redis, [Logger::WARN], 1, 60)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
-require 'minitest'
-require 'minitest/unit'
-require 'minitest/autorun'
-require 'minitest/pride'
-require 'redis'
-require 'logster'
-require 'logster/base_store'
-require 'timecop'
-require 'byebug'
+require "minitest"
+require "minitest/unit"
+require "minitest/autorun"
+require "minitest/pride"
+require "redis"
+require "logster"
+require "logster/base_store"
+require "timecop"
+require "byebug"
 
 class Logster::TestStore < Logster::BaseStore
   attr_accessor :reported

--- a/website/scripts/persist_logs.rb
+++ b/website/scripts/persist_logs.rb
@@ -1,15 +1,15 @@
 # frozen_string_literal: true
 
-require 'redis'
-require 'logster/redis_store'
-require 'logster/message'
-require 'json'
+require "redis"
+require "logster/redis_store"
+require "logster/message"
+require "json"
 
 store = Logster::RedisStore.new(Redis.new)
 latest = store.latest(limit: 1000)
 
 json = JSON.generate(latest)
 
-path = File.expand_path('../../data/data.json', __FILE__)
-File.open(path, 'w') { |f| f.write(json) }
+path = File.expand_path("../../data/data.json", __FILE__)
+File.open(path, "w") { |f| f.write(json) }
 puts "Wrote #{latest.count} messages into #{path}"


### PR DESCRIPTION
Why this change?

The Discourse team has adopted the `syntax_tree` gem to format Ruby files.