### PR TITLE
FEATURE: Format messages with `Logster::Logger#formatter` before storing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+- UNRELEASED
+
+  - FEATURE: Format messages with Logster::Logger#formatter before storing
+
 - 2023-03-10: 2.12.2
 
   - FIX: Don't throw on non-gem backtrace lines

--- a/lib/logster/logger.rb
+++ b/lib/logster/logger.rb
@@ -92,6 +92,8 @@ module Logster
         end
       end
 
+      return if @skip_store
+
       progname ||= @progname
       if message.nil?
         if block_given?
@@ -102,7 +104,7 @@ module Logster
         end
       end
 
-      return if @skip_store
+      message = formatter.call(severity, Time.now, progname, message) if formatter
 
       opts ||= {}
       opts[:env] ||= Thread.current[LOGSTER_ENV]

--- a/test/logster/test_logger.rb
+++ b/test/logster/test_logger.rb
@@ -121,6 +121,12 @@ class TestLogger < Minitest::Test
     assert_equal custom_err.backtrace.join("\n"), @store.calls[2][3][:backtrace]
   end
 
+  def test_formatter
+    @logger.formatter = ->(severity, datetime, progname, msg) { "[test] #{msg}" }
+    @logger.add(0, "hello")
+    assert_equal "[test] hello", @store.calls[0][2]
+  end
+
   private
 
   def error_instance(error_class)


### PR DESCRIPTION
Why this change?

`Logster::Logger` inherits from Ruby's `Logger` class which allows a formatter to be set. By default, `Logger#add` will format messages with `Logger#formatter` if it has been set. Since `Logster::Logger` overrides `Logger#add`, setting a formatter has no effect which is not right considering that `Logster::Logger` should act like a `Logger`.

What does this commit do?

This commit changes `Logster::Logger#add_with_opts` to call the formatter with the message before reporting the message to the store.