### PR TITLE
FEATURE: Stop grouping logs with different messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+- 2024-01-15: 2.14.0
+
+  - FEATURE: Stop grouping logs with different messages
+
 - 2023-11-01: 2.13.1
 
   - FIX: Solve/remove buttons on 'share' page

--- a/lib/logster/message.rb
+++ b/lib/logster/message.rb
@@ -129,7 +129,6 @@ module Logster
 
     # in its own method so it can be overridden
     def grouping_hash
-      message = self.message.gsub(/[0-9a-f]+/i, "X")
       { message: message, severity: self.severity, backtrace: self.backtrace }
     end
 

--- a/lib/logster/version.rb
+++ b/lib/logster/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Logster
-  VERSION = "2.13.1"
+  VERSION = "2.14.0"
 end

--- a/test/logster/test_redis_store.rb
+++ b/test/logster/test_redis_store.rb
@@ -1134,24 +1134,6 @@ class TestRedisStore < Minitest::Test
     end
   end
 
-  def test_messages_that_differ_only_by_numbers_or_hashes_are_merged
-    config_reset(allow_grouping: true) do
-      first_message = <<~TEXT
-        DistributedMutex("download_20450e291e8f1e5ba03ca7f20fb7d9da570c94a6"):
-        held for too long, expected max: 60 secs, took an extra 73 secs
-      TEXT
-      msg = @store.report(Logger::WARN, "", first_message, backtrace: caller)
-
-      second_message = <<~TEXT
-        DistributedMutex("download_e09ae082c60a351dedec67ed869652862b232a0b"):
-        held for too long, expected max: 60 secs, took an extra 287 secs
-      TEXT
-      msg2 = @store.report(Logger::WARN, "", second_message, backtrace: caller)
-
-      assert_equal(msg.key, msg2.key)
-    end
-  end
-
   private
 
   def config_reset(configs)


### PR DESCRIPTION
This was intended to group logs which differed only by some number or hash. However, grouping at this low-level causes the 'message' data for subsequent logs to be completely thrown away, which can be very frustrating when debugging certain problems.

This log-level grouping was originally introduced in 8e067d92, which was added before we had UI-based options for adding custom grouping patterns. Nowadays, those custom grouping patterns are a much better option, and preserve the original message of each log