### PR TITLE
FEATURE: backlink to site

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ Logster can be configured using `Logster.config`:
 
 - `Logster.config.gems_dir` : The value of this config is `Gem.dir + "/gems/"` by default. You probably don't need to change this config, but it's available in case your app gems are installed in a different directory. An example where this config is needed is Logster [demo site](http://logster.info/logs/): [https://github.com/discourse/logster/blob/master/website/sample.rb#L77](https://github.com/discourse/logster/blob/master/website/sample.rb#L77).
 
+- `Logster.config.back_to_site_link_path` : Path for the backlink to site.
+
+- `Logster.config.back_to_site_link_text` : Text for the backlink to site.
+
 ### Tracking Error Rate
 
 Logster allows you to register a callback when the rate of errors has exceeded

--- a/client-app/app/components/back-to-site-link.js
+++ b/client-app/app/components/back-to-site-link.js
@@ -1,0 +1,9 @@
+import Component from "@ember/component";
+import { computed } from "@ember/object";
+
+export default class BackToSiteLink extends Component {
+  @computed("attrs.text", "attrs.path")
+  get shouldDisplay() {
+    return this.text && this.path;
+  }
+}

--- a/client-app/app/controllers/index.js
+++ b/client-app/app/controllers/index.js
@@ -29,6 +29,16 @@ export default class IndexController extends Controller {
     return Preload.get("patterns_enabled");
   }
 
+  @computed
+  get backToSiteLinkText() {
+    return Preload.get("back_to_site_link_text");
+  }
+
+  @computed
+  get backToSiteLinkPath() {
+    return Preload.get("back_to_site_link_path");
+  }
+
   get actionsInMenu() {
     return (
       /mobile/i.test(navigator.userAgent) && !/iPad/.test(navigator.userAgent)

--- a/client-app/app/styles/app.css
+++ b/client-app/app/styles/app.css
@@ -278,6 +278,11 @@ tbody tr {
   overflow: auto;
 }
 
+#back-to-site-panel {
+  padding: 10px;
+  background-color: #f1f1f1;
+}
+
 .message-info {
   position: absolute;
   border-bottom: 1px solid #ddd;

--- a/client-app/app/templates/components/back-to-site-link.hbs
+++ b/client-app/app/templates/components/back-to-site-link.hbs
@@ -1,6 +1,7 @@
 {{#if this.shouldDisplay}}
   <div id="back-to-site-panel">
     <a href={{@path}} rel="noopener noreferrer">
+      <FaIcon @icon="arrow-left" />
       {{@text}}
     </a>
   </div>

--- a/client-app/app/templates/components/back-to-site-link.hbs
+++ b/client-app/app/templates/components/back-to-site-link.hbs
@@ -1,0 +1,7 @@
+{{#if this.shouldDisplay}}
+  <div id="back-to-site-panel">
+    <a href={{@path}} rel="noopener noreferrer">
+      {{@text}}
+    </a>
+  </div>
+{{/if}}

--- a/client-app/app/templates/index.hbs
+++ b/client-app/app/templates/index.hbs
@@ -1,4 +1,8 @@
 <div id="top-panel">
+  <BackToSiteLink
+    @path={{this.backToSiteLinkPath}}
+    @text={{this.backToSiteLinkText}}
+  />
   <div id="log-table">
     {{#if this.model.moreBefore}}
       <div {{on "click" this.showMoreBefore}} class="show-more">

--- a/client-app/config/icons.js
+++ b/client-app/config/icons.js
@@ -1,6 +1,7 @@
 module.exports = function () {
   return {
     "free-solid-svg-icons": [
+      "arrow-left",
       "check-square",
       "trash-alt",
       "ellipsis-h",

--- a/client-app/tests/integration/components/back-to-site-link-test.js
+++ b/client-app/tests/integration/components/back-to-site-link-test.js
@@ -1,0 +1,20 @@
+import { module, test } from "qunit";
+import { setupRenderingTest } from "ember-qunit";
+import { render } from "@ember/test-helpers";
+import hbs from "htmlbars-inline-precompile";
+
+module("Integration | Component | back-to-site-link", function (hooks) {
+  setupRenderingTest(hooks);
+
+  test("With path and text paremeter", async function (assert) {
+    await render(hbs`<BackToSiteLink @path="/admin" @text="back to site"/>`);
+    assert.dom("#back-to-site-panel a").exists("It shows back link to site");
+  });
+
+  test("Without required paremeters", async function (assert) {
+    await render(hbs`<BackToSiteLink />`);
+    assert
+      .dom("#back-to-site-panel a")
+      .doesNotExist("It does not show back link to site");
+  });
+});

--- a/client-app/tests/integration/components/back-to-site-link-test.js
+++ b/client-app/tests/integration/components/back-to-site-link-test.js
@@ -8,7 +8,7 @@ module("Integration | Component | back-to-site-link", function (hooks) {
 
   test("With path and text paremeter", async function (assert) {
     await render(hbs`<BackToSiteLink @path="/admin" @text="back to site"/>`);
-    assert.dom("#back-to-site-panel a").exists("It shows back link to site");
+    assert.dom("#back-to-site-panel a").exists("It shows back to site link");
   });
 
   test("Without required paremeters", async function (assert) {

--- a/lib/logster/configuration.rb
+++ b/lib/logster/configuration.rb
@@ -20,6 +20,8 @@ module Logster
       :max_env_count_per_message,
       :maximum_message_length,
       :use_full_hostname,
+      :back_to_site_link_text,
+      :back_to_site_link_path,
     )
 
     attr_writer :subdirectory

--- a/lib/logster/middleware/viewer.rb
+++ b/lib/logster/middleware/viewer.rb
@@ -335,6 +335,12 @@ module Logster
         preload.merge!(gems_dir: gems_dir, backtrace_links_enabled: backtrace_links_enabled)
 
         preload.merge!(preload_backtrace_data) if backtrace_links_enabled
+        if Logster.config.back_to_site_link_text && Logster.config.back_to_site_link_path
+          preload.merge!(
+            back_to_site_link_text: Logster.config.back_to_site_link_text,
+            back_to_site_link_path: Logster.config.back_to_site_link_path,
+          )
+        end
         preload
       end
 


### PR DESCRIPTION
Introduce two configuration attributes `back_to_site_link_text` and `back_to_site_link_path`.

It is used to display the backlink to the original site.

Deskop
<img width="1215" alt="Screenshot 2024-02-15 at 9 31 18 am" src="https://github.com/discourse/logster/assets/72780/a4f90853-73c3-4ffe-a5fb-29b305eb024c">

Link
<img width="429" alt="Screenshot 2024-02-15 at 9 31 34 am" src="https://github.com/discourse/logster/assets/72780/6bad6b9e-b6b5-4499-b71d-1ee694ad0ba9">
