### PR TITLE
UX: backlink in dark mode has a dark background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+- 2024002-19: 2.18.1
+
+  - UX: backlink in dark mode has a dark background
+
 - 2024-02-15: 2.18.0
 
   - FEATURE: Implement a default Content-Security-Policy

--- a/client-app/app/styles/app.css
+++ b/client-app/app/styles/app.css
@@ -822,4 +822,8 @@ label span {
   .expand-list {
     color: #44f;
   }
+
+  #back-to-site-panel {
+    background-color: #181818;
+  }
 }

--- a/lib/logster/version.rb
+++ b/lib/logster/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Logster
-  VERSION = "2.18.0"
+  VERSION = "2.18.1"
 end


### PR DESCRIPTION
Demo dark mode

<img width="1390" alt="Screenshot 2024-02-19 at 8 17 05 am" src="https://github.com/discourse/logster/assets/72780/f29c01d0-a0ad-440d-b282-9662fd0d61c7">

Demo light mode
<img width="1388" alt="Screenshot 2024-02-19 at 8 25 57 am" src="https://github.com/discourse/logster/assets/72780/b076c04e-8b6f-416d-8682-1eb80330b2f9">

