### PR TITLE
DEV: Fix flaky test seen on CI

### DIFF
--- a/lib/logster/redis_store.rb
+++ b/lib/logster/redis_store.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require "json"
+# Disable rubocop because the require is only redundant for Ruby 3.2+ but we still support Ruby 3.1
+require "set" # rubocop:disable Lint/RedundantRequireStatement
 require "logster/base_store"
 require "logster/redis_rate_limiter"
 


### PR DESCRIPTION
Error seen on [CI](https://github.com/discourse/logster/actions/runs/9738588499/job/26872415812?pr=233):

```
Error:
TestRedisStore#test_solving_with_some_missing_version:
NameError: uninitialized constant Logster::RedisStore::Set
    lib/logster/redis_store.rb:396:in `clear_solved'
    lib/logster/redis_store.rb:99:in `solve'
    test/logster/test_redis_store.rb:742:in `test_solving_with_some_missing_version'
```

