### PR TITLE
FEATURE: Update `Logster::Logger#chain` method to accept `with_opts`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
   - Dropped support for Ruby 3.0
 
+  - Update `Logster::Logger#chain` to accept a `with_opts` keyword argument. When set to `true`, an instance of `Logster::Logger`
+    will call the chained logger's `add` method with an extra `opts` parameter.
+
 - 2024-03-12: 2.19.1
 
   - FIX: Don’t truncate backtrace on copying


### PR DESCRIPTION
This commit updates `Logster::Logger#chain` method to accept a
`with_opts` keyword argument which when set to `true` will call the
chained logger's `add` methood with an extra `opts` parameter which is a
hash consistenting of Logster's env and other useful information like the
backtrace of an exception.

This improves `Logster::Logger#chain` API so that other loggers can
benefit from the envs and backtraces that Logster has already
painstakingly gathered.
