### PR TITLE
Add `Logster::Logger#subscribe` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # CHANGELOG
 
-- UNRELEASED
+- 2024-07-05: 2.20.0
 
   - Dropped support for Ruby 3.0
+  - Add `Logster::Logger#subscribe` which allows subscribing to log events from `Logster::Logger`.
 
 - 2024-03-12: 2.19.1
 

--- a/lib/logster/version.rb
+++ b/lib/logster/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Logster
-  VERSION = "2.19.1"
+  VERSION = "2.20.0"
 end


### PR DESCRIPTION
This commit adds a `Logster::Logger#subscribe` method which allows users
to subscribe to log events for `Logster::Logger` but with additional
options that have already been gathered by Logster.
