### PR TITLE
FIX: Don't break search when providing invalid regex characters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,8 @@ jobs:
 
     strategy:
       matrix:
-        ruby: ["3.1", "3.2", "3.3"]
-        rails: ["6.1", "7.0", "7.1"]
+        ruby: ["3.2", "3.3", "3.4"]
+        rails: ["6.1", "7.0", "7.1", "7.2"]
 
     env:
       BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/rails_${{ matrix.rails }}.gemfile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+- 2025-02-06: 2.20.1
+
+  - FIX: Don't break search when providing invalid regex characters
+
 - 2024-07-05: 2.20.0
 
   - Dropped support for Ruby 3.0

--- a/gemfiles/rails_7.0.gemfile
+++ b/gemfiles/rails_7.0.gemfile
@@ -4,6 +4,9 @@ source "https://rubygems.org"
 
 group :test do
   gem "rails", "~> 7.0.0"
+  gem "concurrent-ruby", "1.3.4"
+  gem "mutex_m"
+  gem "bigdecimal"
 end
 
 gemspec path: "../"

--- a/gemfiles/rails_7.2.gemfile
+++ b/gemfiles/rails_7.2.gemfile
@@ -3,10 +3,7 @@
 source "https://rubygems.org"
 
 group :test do
-  gem "rails", "~> 6.1.0"
-  gem "concurrent-ruby", "1.3.4"
-  gem "mutex_m"
-  gem "bigdecimal"
+  gem "rails", "~> 7.2.0"
 end
 
 gemspec path: "../"

--- a/lib/logster/redis_store.rb
+++ b/lib/logster/redis_store.rb
@@ -534,7 +534,7 @@ module Logster
           when Regexp
             value.to_s =~ search
           when String
-            value.to_s =~ Regexp.new(search, Regexp::IGNORECASE)
+            value.to_s =~ Regexp.new(Regexp.escape(search), Regexp::IGNORECASE)
           else
             false
           end

--- a/lib/logster/version.rb
+++ b/lib/logster/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Logster
-  VERSION = "2.20.0"
+  VERSION = "2.20.1"
 end

--- a/test/logster/test_redis_store.rb
+++ b/test/logster/test_redis_store.rb
@@ -428,6 +428,16 @@ class TestRedisStore < Minitest::Test
     assert_equal("TUVWXYZ", latest[0].message)
   end
 
+  def test_search_works_with_invalid_regex_chars
+    @store.report(Logger::INFO, "test", "ABCDEFG\\")
+    @store.report(Logger::INFO, "test", "TUVWXYZ")
+
+    result = @store.latest(search: "EFG\\")
+
+    assert_equal(1, result.size)
+    assert_equal("ABCDEFG\\", result[0].message)
+  end
+
   def test_search_exclude_results
     @store.report(Logger::INFO, "test", "ABCDEFG")
     @store.report(Logger::INFO, "test", "TUVWXYZ")


### PR DESCRIPTION
Searching through messages accepts terms as a regexp or a string. When a regexp is provided, it is parsed and checked, and if it’s invalid, then it’s discarded, without raising an error. But when a string is provided, we convert it to a regexp as-is and if it results in an invalid regexp, then an error is raised.

This PR addresses that issue by escaping the string before converting it to a regexp, that way it can’t create an invalid regexp anymore.